### PR TITLE
Fix typos in comments

### DIFF
--- a/sources/Core/LinealgOptions.cs
+++ b/sources/Core/LinealgOptions.cs
@@ -1800,7 +1800,7 @@ namespace UMapx.Core
         }
 
         /// <summary>
-        /// Implements local average of matrice (horizontal).
+        /// Implements local average of matrix (horizontal).
         /// </summary>
         /// <param name="A">Jagged array</param>
         /// <param name="r1">Size</param>
@@ -1848,7 +1848,7 @@ namespace UMapx.Core
             return H;
         }
         /// <summary>
-        /// Implements local average of matrice (vertical).
+        /// Implements local average of matrix (vertical).
         /// </summary>
         /// <param name="A">Jagged array</param>
         /// <param name="r0">Size</param>
@@ -1897,7 +1897,7 @@ namespace UMapx.Core
             return H;
         }
         /// <summary>
-        /// Implements local average of matrice (horizontal).
+        /// Implements local average of matrix (horizontal).
         /// </summary>
         /// <param name="A">Jagged array</param>
         /// <param name="r1">Size</param>
@@ -1945,7 +1945,7 @@ namespace UMapx.Core
             return H;
         }
         /// <summary>
-        /// Implements local average of matrice (vertical).
+        /// Implements local average of matrix (vertical).
         /// </summary>
         /// <param name="A">Jagged array</param>
         /// <param name="r0">Size</param>
@@ -2132,7 +2132,7 @@ namespace UMapx.Core
         }
 
         /// <summary>
-        /// Implements local weighted average of matrice (horizontal).
+        /// Implements local weighted average of matrix (horizontal).
         /// </summary>
         /// <param name="A">Jagged array</param>
         /// <param name="weights">Weights</param>
@@ -2205,7 +2205,7 @@ namespace UMapx.Core
             return result;
         }
         /// <summary>
-        /// Implements local weighted average of matrice (vertical).
+        /// Implements local weighted average of matrix (vertical).
         /// </summary>
         /// <param name="A">Jagged array</param>
         /// <param name="weights">Weights</param>
@@ -2277,7 +2277,7 @@ namespace UMapx.Core
             return result;
         }
         /// <summary>
-        /// Implements local weighted average of matrice (horizontal).
+        /// Implements local weighted average of matrix (horizontal).
         /// </summary>
         /// <param name="A">Jagged array</param>
         /// <param name="weights">Weights</param>
@@ -2350,7 +2350,7 @@ namespace UMapx.Core
             return result;
         }
         /// <summary>
-        /// Implements local weighted average of matrice (vertical).
+        /// Implements local weighted average of matrix (vertical).
         /// </summary>
         /// <param name="A">Jagged array</param>
         /// <param name="weights">Weights</param>


### PR DESCRIPTION
## Summary
- fix typo 'matrice' -> 'matrix' in lineal operations comments

## Testing
- `dotnet test sources/UMapx.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68a0f513d8d08321aa1f8b0b6ee122d1