### PR TITLE
Fix imaginary sign in float-complex subtraction

### DIFF
--- a/sources/Core/ComplexF.cs
+++ b/sources/Core/ComplexF.cs
@@ -184,7 +184,7 @@ namespace UMapx.Core
         /// <returns>Complex number</returns>
         public static ComplexF operator -(float a, ComplexF b)
         {
-            return new ComplexF(a - b.Real, b.Imag);
+            return new ComplexF(a - b.Real, -b.Imag);
         }
         /// <summary>
         /// Inverts complex number.


### PR DESCRIPTION
## Summary
- fix float-minus-complex operator to negate imaginary part
- reviewed other complex operators for consistent sign usage

## Testing
- `dotnet test sources/UMapx.csproj`
- `dotnet build sources/UMapx.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68b84a15ac048321b3805c774e71da16