### PR TITLE
Normalize HEX input

### DIFF
--- a/sources/Colorspace/RGB.cs
+++ b/sources/Colorspace/RGB.cs
@@ -232,7 +232,8 @@ namespace UMapx.Colorspace
         {
             string r, g, b;
 
-            hexColor = hexColor.Trim();
+            // Trim and normalize to uppercase to handle case-insensitive HEX values
+            hexColor = hexColor.Trim().ToUpperInvariant();
             if (hexColor[0] == '#') hexColor = hexColor.Substring(1, hexColor.Length - 1);
 
             r = hexColor.Substring(0, 2);


### PR DESCRIPTION
## Summary
- Ensure HEX parsing handles lowercase digits by normalizing to uppercase in `FromHEX`
- Add a comment explaining case-insensitive handling

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b84eb0e5708321af6546e07360d255