### PR TITLE
docs: correct CMYK conversion comment

### DIFF
--- a/sources/Colorspace/CMYK.cs
+++ b/sources/Colorspace/CMYK.cs
@@ -193,7 +193,7 @@ namespace UMapx.Colorspace
             }
         }
         /// <summary>
-        /// Converts a color model RGB in model HSB.
+        /// Converts a color model RGB to the CMYK model.
         /// </summary>
         /// <param name="rgb">RGB structure</param>
         /// <returns>CMYK structure</returns>


### PR DESCRIPTION
## Summary
- fix FromRGB method documentation to reference CMYK instead of HSB

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68b852684c308321aa018f86fd3875f1