### PR TITLE
fix: correct symmetry comments

### DIFF
--- a/sources/Core/MatrixF.cs
+++ b/sources/Core/MatrixF.cs
@@ -117,7 +117,7 @@ namespace UMapx.Core
         {
             if (MatrixF.IsSquare(m))
             {
-                // ?A = A'
+                // A = Aᵀ
                 if (MatrixF.IsEquals(m, m.Transponate()))
                 {
                     return true;
@@ -134,7 +134,7 @@ namespace UMapx.Core
         {
             if (MatrixF.IsSquare(m))
             {
-                // ?A' = -A:
+                // Aᵀ = -A:
                 if (MatrixF.IsEquals(m.Transponate(), m.ToNegate()))
                 {
                     return true;
@@ -203,7 +203,7 @@ namespace UMapx.Core
         {
             if (MatrixF.IsSquare(m))
             {
-                // ?A = A'
+                // A = Aᵀ
                 if (MatrixF.IsEquals(m, MatrixF.Hermitian(m)))
                 {
                     return true;
@@ -220,7 +220,7 @@ namespace UMapx.Core
         {
             if (MatrixF.IsSquare(m))
             {
-                // ?A' = -A
+                // Aᵀ = -A
                 if (MatrixF.IsEquals(m.Hermitian(), m.ToNegate()))
                 {
                     return true;


### PR DESCRIPTION
## Summary
- clarify symmetric and skew-symmetric matrix comments to use standard transpose notation

## Testing
- `dotnet test sources/UMapx.sln`
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68b85261543083218f326d0c1f70b4c0