### PR TITLE
Fix HSL ToRGB component comments

### DIFF
--- a/sources/Colorspace/HSL.cs
+++ b/sources/Colorspace/HSL.cs
@@ -240,8 +240,8 @@ namespace UMapx.Colorspace
                     float[] T = new float[3];
 
                     T[0] = Hk + 0.3333f;	// Tr
-                    T[1] = Hk;				// Tb
-                    T[2] = Hk - 0.3333f;	// Tg
+                    T[1] = Hk;				// Tg
+                    T[2] = Hk - 0.3333f;	// Tb
 
                     for (int i = 0; i < 3; i++)
                     {


### PR DESCRIPTION
## Summary
- Correct comments for Tg and Tb in HSL.ToRGB to match array usage

## Testing
- `dotnet build sources/UMapx.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b86f9d31e48321bedb3ba1a579fc5e