### PR TITLE
Fix spelling of coefficients in comments

### DIFF
--- a/sources/Core/Matrice.cs
+++ b/sources/Core/Matrice.cs
@@ -6696,7 +6696,7 @@ namespace UMapx.Core
 
             // destination pixel's coordinate relative to image center
             float cx, cy;
-            // coordinates of source points and cooefficiens
+            // coordinates of source points and coefficients
             float ox, oy, dx, dy, k1, k2;
             int ox1, oy1, ox2, oy2;
             // destination pixel values
@@ -7090,7 +7090,7 @@ namespace UMapx.Core
 
             // destination pixel's coordinate relative to image center
             float cx, cy;
-            // coordinates of source points and cooefficiens
+            // coordinates of source points and coefficients
             float ox, oy, dx, dy, k1, k2;
             int ox1, oy1, ox2, oy2;
             // destination pixel values
@@ -7215,7 +7215,7 @@ namespace UMapx.Core
             float xFactor = (float)width / w;
             float yFactor = (float)height / h;
 
-            // coordinates of source points and cooefficiens
+            // coordinates of source points and coefficients
             float ox, oy, dx, dy, k1, k2;
             int ox1, oy1, ox2, oy2;
             float g;
@@ -7421,7 +7421,7 @@ namespace UMapx.Core
             float xFactor = (float)width / w;
             float yFactor = (float)height / h;
 
-            // coordinates of source points and cooefficiens
+            // coordinates of source points and coefficients
             float ox, oy, dx, dy, k1, k2;
             int ox1, oy1, ox2, oy2;
             Complex32 g;
@@ -7623,7 +7623,7 @@ namespace UMapx.Core
 
             float yFactor = (float)height / h;
 
-            // coordinates of source points and cooefficiens
+            // coordinates of source points and coefficients
             float oy, dy, k1;
             int oy1, oy2;
             float g;
@@ -7779,7 +7779,7 @@ namespace UMapx.Core
 
             float yFactor = (float)height / h;
 
-            // coordinates of source points and cooefficiens
+            // coordinates of source points and coefficients
             float oy, dy, k1;
             int oy1, oy2;
             Complex32 g;

--- a/sources/Imaging/Resize.cs
+++ b/sources/Imaging/Resize.cs
@@ -225,7 +225,7 @@ namespace UMapx.Imaging
             byte* src = (byte*)bmSrc.Scan0.ToPointer();
             byte* dst = (byte*)bmData.Scan0.ToPointer();
 
-            // coordinates of source points and cooefficiens
+            // coordinates of source points and coefficients
             float ox, oy, dx, dy, k1, k2;
             int ox1, oy1, ox2, oy2;
             // destination pixel values


### PR DESCRIPTION
## Summary
- fix typo "cooefficiens" to "coefficients" in Resize and Matrice comments

## Testing
- `dotnet test` *(fails: MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c1dd1448321a3dbb01db6c330bd