### PR TITLE
Use using declarations for FileStream in XML helpers

### DIFF
--- a/sources/Core/Xml.cs
+++ b/sources/Core/Xml.cs
@@ -27,11 +27,9 @@ namespace UMapx.Core
         /// <param name="o">Object</param>
         public static void Save(string fileName, object o)
         {
-            FileStream stream = new FileStream(fileName, FileMode.Create, FileAccess.Write);
+            using var stream = new FileStream(fileName, FileMode.Create, FileAccess.Write);
             XmlSerializer xml = new XmlSerializer(o.GetType());
             xml.Serialize(stream, o);
-            stream.Close();
-            stream.Dispose();
         }
         /// <summary>
         /// Load data from the file.
@@ -50,12 +48,9 @@ namespace UMapx.Core
         /// <param name="type">Type</param>
         public static object Open(string fileName, Type type)
         {
-            FileStream stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
+            using var stream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
             XmlSerializer xml = new XmlSerializer(type);
-            object graph = xml.Deserialize(stream);
-            stream.Close();
-            stream.Dispose();
-            return graph;
+            return xml.Deserialize(stream);
         }
         #endregion
     }


### PR DESCRIPTION
## Summary
- rely on `using` declarations for `FileStream` when saving or opening XML
- drop explicit `Close`/`Dispose` calls

## Testing
- `dotnet build sources/UMapx.sln`
- `dotnet test sources/UMapx.sln` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2c7a74ac8321bceaf4cafab7c1f2