### PR TITLE
Fix Complex32 Parse returns documentation

### DIFF
--- a/sources/Core/Complex32.cs
+++ b/sources/Core/Complex32.cs
@@ -402,7 +402,7 @@ namespace UMapx.Core
         /// </remarks>
         /// </summary>
         /// <param name="s">Input string</param>
-        /// <returns>Text as a sequence of Unicode characters</returns>
+        /// <returns>Complex number</returns>
         public static Complex32 Parse(string s)
         {
             return StringOptions.Compar(s);


### PR DESCRIPTION
## Summary
- correct Parse documentation to state it returns a complex number

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba304740508321b21dc8a7516ddfdd