### PR TITLE
Fix yellow parameter documentation in RYB float constructor

### DIFF
--- a/sources/Colorspace/RYB.cs
+++ b/sources/Colorspace/RYB.cs
@@ -32,7 +32,7 @@ namespace UMapx.Colorspace
         /// Creates an instance of the structure RYB.
         /// </summary>
         /// <param name="red">Red [0, 255]</param>
-        /// <param name="yellow">Green [0, 255]</param>
+        /// <param name="yellow">Yellow [0, 255]</param>
         /// <param name="blue">Blue [0, 255]</param>
         public RYB(float red, float yellow, float blue)
         {


### PR DESCRIPTION
## Summary
- Fix yellow parameter docstring for RYB float constructor

## Testing
- `dotnet test sources/UMapx.sln` *(no tests found)*
- `dotnet build sources/UMapx.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68ba2feb24fc8321b96fe08fd4f0e055