### PR TITLE
Fix XML docs for determinant parameters

### DIFF
--- a/sources/Core/LinealgOptions.cs
+++ b/sources/Core/LinealgOptions.cs
@@ -26,8 +26,8 @@ namespace UMapx.Core
             /// <summary>
             /// Iterative calculation of the determinant.
             /// </summary>
-            /// <param name="element">"Element</param>
-            /// <param name="n">Radius</param>
+            /// <param name="element">Element</param>
+            /// <param name="n">Matrix size</param>
             /// <returns>Value</returns>
             public unsafe static float Determinant(float* element, int n)
             {
@@ -73,8 +73,8 @@ namespace UMapx.Core
             /// <summary>
             /// Iterative calculation of the determinant.
             /// </summary>
-            /// <param name="element">"Element</param>
-            /// <param name="n">Radius</param>
+            /// <param name="element">Element</param>
+            /// <param name="n">Matrix size</param>
             /// <returns>Complex number</returns>
             public unsafe static Complex32 Determinant(Complex32* element, int n)
             {


### PR DESCRIPTION
## Summary
- fix stray quote in `<param name="element">` XML docs
- clarify `n` parameter description as matrix size

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68ba323f58d48321b3ec3d15fc5b9c13