### PR TITLE
Fix Abel polynomial parameter type

### DIFF
--- a/sources/Core/Special.cs
+++ b/sources/Core/Special.cs
@@ -90,10 +90,10 @@ namespace UMapx.Core
         /// Returns the value of the Abel polynomial.
         /// </summary>
         /// <param name="x">Value</param>
-        /// <param name="a">Power</param>
+        /// <param name="a">Complex power</param>
         /// <param name="n">Order</param>
         /// <returns>Value</returns>
-        public static Complex32 Abel(Complex32 x, float a, int n)
+        public static Complex32 Abel(Complex32 x, Complex32 a, int n)
         {
             if (n < 0) return Complex32.NaN;
             if (n == 0) return 1;


### PR DESCRIPTION
## Summary
- use Complex32 for `a` in complex Abel polynomial overload
- document new complex parameter type

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68ba324b12048321819218ba4b2893dc