### PR TITLE
Correct coefficient spelling in imaging transforms

### DIFF
--- a/sources/Imaging/DepthTransform.cs
+++ b/sources/Imaging/DepthTransform.cs
@@ -140,7 +140,7 @@ namespace UMapx.Imaging
 
             // destination pixel's coordinate relative to image center
             float cx, cy;
-            // coordinates of source points and cooefficiens
+            // coordinates of source points and coefficients
             float ox, oy, dx, dy, k1, k2;
             int ox1, oy1, ox2, oy2;
             // destination pixel values
@@ -367,7 +367,7 @@ namespace UMapx.Imaging
             float xFactor = (float)width / w;
             float yFactor = (float)height / h;
 
-            // coordinates of source points and cooefficiens
+            // coordinates of source points and coefficients
             float ox, oy, dx, dy, k1, k2;
             int ox1, oy1, ox2, oy2;
             float g;

--- a/sources/Imaging/Rotate.cs
+++ b/sources/Imaging/Rotate.cs
@@ -387,7 +387,7 @@ namespace UMapx.Imaging
 
             // destination pixel's coordinate relative to image center
             float cx, cy;
-            // coordinates of source points and cooefficiens
+            // coordinates of source points and coefficients
             float ox, oy, dx, dy, k1, k2;
             int ox1, oy1, ox2, oy2;
             // destination pixel values


### PR DESCRIPTION
## Summary
- fix coefficient spelling in depth transform comments
- fix coefficient spelling in rotate comments

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68ba36f07f888321b56a242970b59a65