### PR TITLE
Fix 90° rotation indexing for matrices and depth maps

### DIFF
--- a/sources/Core/Matrice.cs
+++ b/sources/Core/Matrice.cs
@@ -6414,7 +6414,7 @@ namespace UMapx.Core
             {
                 for (int j = 0; j < w; j++)
                 {
-                    H[j, i] = input[h - i - 1, w - j - 1];
+                    H[j, h - 1 - i] = input[i, j];
                 }
             }
 
@@ -6458,7 +6458,7 @@ namespace UMapx.Core
             {
                 for (int j = 0; j < w; j++)
                 {
-                    H[j, i] = input[i, w - j - 1];
+                    H[w - 1 - j, i] = input[i, j];
                 }
             }
 
@@ -6808,7 +6808,7 @@ namespace UMapx.Core
             {
                 for (int j = 0; j < w; j++)
                 {
-                    H[j, i] = input[h - i - 1, w - j - 1];
+                    H[j, h - 1 - i] = input[i, j];
                 }
             }
 
@@ -6852,7 +6852,7 @@ namespace UMapx.Core
             {
                 for (int j = 0; j < w; j++)
                 {
-                    H[j, i] = input[i, w - j - 1];
+                    H[w - 1 - j, i] = input[i, j];
                 }
             }
 

--- a/sources/Imaging/DepthTransform.cs
+++ b/sources/Imaging/DepthTransform.cs
@@ -50,7 +50,7 @@ namespace UMapx.Imaging
             {
                 for (int j = 0; j < w; j++)
                 {
-                    H[j, i] = input[h - i - 1, w - j - 1];
+                    H[j, h - 1 - i] = input[i, j];
                 }
             }
 
@@ -94,7 +94,7 @@ namespace UMapx.Imaging
             {
                 for (int j = 0; j < w; j++)
                 {
-                    H[j, i] = input[i, w - j - 1];
+                    H[w - 1 - j, i] = input[i, j];
                 }
             }
 


### PR DESCRIPTION
## Summary
- correct source indices for 90° rotation in `DepthTransform.Rotate90`
- align `Rotate270` to new orientation
- update matrix and complex rotation helpers with proper index mapping

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68ba3676ae248321946176c5fd6acba4