### PR TITLE
Fix typo in Analysis method selection comments

### DIFF
--- a/sources/Analysis/Approximation.cs
+++ b/sources/Analysis/Approximation.cs
@@ -72,7 +72,7 @@ namespace UMapx.Analysis
         /// <returns>Array</returns>
         public float[] Compute(float[] x, float[] y)
         {
-            // chose method of approximation
+            // choose method of approximation
             switch (method)
             {
                 case ApproximationMethod.Polynomial:
@@ -97,7 +97,7 @@ namespace UMapx.Analysis
         /// <returns>Array</returns>
         public float[] Compute(float[] x, float[] y, out float[] cf)
         {
-            // chose method of approximation
+            // choose method of approximation
             switch (method)
             {
                 case ApproximationMethod.Polynomial:
@@ -123,7 +123,7 @@ namespace UMapx.Analysis
         /// <returns>Array</returns>
         public float[] Compute(float[] x, float[] y, out float[] cf, out float similarity)
         {
-            // chose method of approximation
+            // choose method of approximation
             switch (method)
             {
                 case ApproximationMethod.Polynomial:
@@ -150,7 +150,7 @@ namespace UMapx.Analysis
         /// <returns>Array</returns>
         public float[] Compute(float[] x, float[] y, out float[] cf, out float similarity, out string equation)
         {
-            // chose method of approximation
+            // choose method of approximation
             switch (method)
             {
                 case ApproximationMethod.Polynomial:
@@ -175,7 +175,7 @@ namespace UMapx.Analysis
         /// <returns>Array</returns>
         public Complex32[] Compute(Complex32[] x, Complex32[] y)
         {
-            // chose method of approximation
+            // choose method of approximation
             switch (method)
             {
                 case ApproximationMethod.Polynomial:
@@ -200,7 +200,7 @@ namespace UMapx.Analysis
         /// <returns>Array</returns>
         public Complex32[] Compute(Complex32[] x, Complex32[] y, out Complex32[] cf)
         {
-            // chose method of approximation
+            // choose method of approximation
             switch (method)
             {
                 case ApproximationMethod.Polynomial:
@@ -226,7 +226,7 @@ namespace UMapx.Analysis
         /// <returns>Array</returns>
         public Complex32[] Compute(Complex32[] x, Complex32[] y, out Complex32[] cf, out Complex32 similarity)
         {
-            // chose method of approximation
+            // choose method of approximation
             switch (method)
             {
                 case ApproximationMethod.Polynomial:
@@ -253,7 +253,7 @@ namespace UMapx.Analysis
         /// <returns>Array</returns>
         public Complex32[] Compute(Complex32[] x, Complex32[] y, out Complex32[] cf, out Complex32 similarity, out string equation)
         {
-            // chose method of approximation
+            // choose method of approximation
             switch (method)
             {
                 case ApproximationMethod.Polynomial:

--- a/sources/Analysis/Differential.cs
+++ b/sources/Analysis/Differential.cs
@@ -48,7 +48,7 @@ namespace UMapx.Analysis
         /// <returns>Array of function values</returns>
         public float[] Compute(IFloatMesh function, float[] x, float y0)
         {
-            // chose method of differentiation
+            // choose method of differentiation
             switch (method)
             {
                 case DifferentialMethod.Euler:
@@ -73,7 +73,7 @@ namespace UMapx.Analysis
         /// <returns>Array of function values</returns>
         public Complex32[] Compute(IComplex32Mesh function, Complex32[] x, Complex32 y0)
         {
-            // chose method of differentiation
+            // choose method of differentiation
             switch (method)
             {
                 case DifferentialMethod.Euler:

--- a/sources/Analysis/Integration.cs
+++ b/sources/Analysis/Integration.cs
@@ -49,7 +49,7 @@ namespace UMapx.Analysis
         /// <returns>Value</returns>
         public float Compute(IFloat function, float a, float b, int n)
         {
-            // chose method of integration
+            // choose method of integration
             switch (method)
             {
                 case IntegrationMethod.Midpoint:
@@ -78,7 +78,7 @@ namespace UMapx.Analysis
         /// <returns>Value</returns>
         public float Compute(float[] y, float a, float b, int n)
         {
-            // chose method of integration
+            // choose method of integration
             switch (method)
             {
                 case IntegrationMethod.Midpoint:
@@ -107,7 +107,7 @@ namespace UMapx.Analysis
         /// <returns>Complex number</returns>
         public Complex32 Compute(IComplex32 function, Complex32 a, Complex32 b, int n)
         {
-            // chose method of integration
+            // choose method of integration
             switch (method)
             {
                 case IntegrationMethod.Midpoint:
@@ -136,7 +136,7 @@ namespace UMapx.Analysis
         /// <returns>Complex number</returns>
         public Complex32 Compute(Complex32[] y, Complex32 a, Complex32 b, int n)
         {
-            // chose method of integration
+            // choose method of integration
             switch (method)
             {
                 case IntegrationMethod.Midpoint:

--- a/sources/Analysis/Interpolation.cs
+++ b/sources/Analysis/Interpolation.cs
@@ -64,7 +64,7 @@ namespace UMapx.Analysis
         /// <returns>Value</returns>
         public float Compute(float[] x, float[] y, float xl)
         {
-            // chose method of interpolation
+            // choose method of interpolation
             switch (method)
             {
                 case InterpolationMethod.Newton:
@@ -90,7 +90,7 @@ namespace UMapx.Analysis
         /// <returns>Complex number</returns>
         public Complex32 Compute(Complex32[] x, Complex32[] y, Complex32 xl)
         {
-            // chose method of interpolation
+            // choose method of interpolation
             switch (method)
             {
                 case InterpolationMethod.Newton:

--- a/sources/Analysis/Nonlinear.cs
+++ b/sources/Analysis/Nonlinear.cs
@@ -65,7 +65,7 @@ namespace UMapx.Analysis
         /// <returns>Value</returns>
         public float Compute(IFloat function, float a, float b)
         {
-            // chose method of nonlinear
+            // choose method of nonlinear
             switch (method)
             {
                 case NonlinearMethod.Chord:
@@ -87,7 +87,7 @@ namespace UMapx.Analysis
         /// <returns>Value</returns>
         public Complex32 Compute(IComplex32 function, Complex32 a, Complex32 b)
         {
-            // chose method of nonlinear
+            // choose method of nonlinear
             switch (method)
             {
                 case NonlinearMethod.Chord:


### PR DESCRIPTION
## Summary
- replace 'chose method' with 'choose method' across analysis helpers

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68ba39bbd3ac8321b96dd12baf3749c3