### PR TITLE
refactor: move remarks outside summary

### DIFF
--- a/sources/Analysis/Approximation.cs
+++ b/sources/Analysis/Approximation.cs
@@ -5,12 +5,12 @@ namespace UMapx.Analysis
 {
     /// <summary>
     /// Defines the least squares approximation class.
+    /// </summary>
     /// <remarks>
     /// This class is a solution to the problem of finding the function A (x) ≈ F (x), where F (x) is the original function.
     /// More information can be found on the website:
     /// http://simenergy.ru/math-analysis/digital-processing/85-ordinary_least_squares
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Approximation
     {

--- a/sources/Analysis/Differential.cs
+++ b/sources/Analysis/Differential.cs
@@ -5,10 +5,10 @@ namespace UMapx.Analysis
 {
     /// <summary>
     /// Defines a class that implements a solution to a differential equation.
+    /// </summary>
     /// <remarks>
     /// This class is a solution to the Cauchy problem for the ordinary differential equation y' = F(x, y).
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Differential
     {

--- a/sources/Analysis/Integration.cs
+++ b/sources/Analysis/Integration.cs
@@ -5,10 +5,10 @@ namespace UMapx.Analysis
 {
     /// <summary>
     /// Defines a class that implements numerical integration.
+    /// </summary>
     /// <remarks>
     /// This class is a solution to the problem of finding the value of the integral of the function F(x) within the values of a and b.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Integration
     {

--- a/sources/Analysis/Interpolation.cs
+++ b/sources/Analysis/Interpolation.cs
@@ -5,10 +5,10 @@ namespace UMapx.Analysis
 {
     /// <summary>
     /// Defines a class that implements interpolation.
+    /// </summary>
     /// <remarks>
     /// This class is a solution to the problem of finding an intermediate value of the function F(x).
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Interpolation
     {
@@ -41,10 +41,10 @@ namespace UMapx.Analysis
         }
         /// <summary>
         /// Returns the value of a function at a point.
+        /// </summary>
         /// <remarks>
         /// In this case, only bilinear interpolation is used.
         /// </remarks>
-        /// </summary>
         /// <param name="x">Array of values of the first argument</param>
         /// <param name="y">Array of values of the second argument</param>
         /// <param name="z">Function matrix</param>

--- a/sources/Analysis/Nonlinear.cs
+++ b/sources/Analysis/Nonlinear.cs
@@ -5,10 +5,10 @@ namespace UMapx.Analysis
 {
     /// <summary>
     /// Defines a class that implements the solution of a nonlinear equation.
+    /// </summary>
     /// <remarks>
     /// This class is a solution to the problem of finding the root of a nonlinear equation of the form F(x) = 0.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Nonlinear
     {

--- a/sources/Analysis/Optimization.cs
+++ b/sources/Analysis/Optimization.cs
@@ -5,10 +5,10 @@ namespace UMapx.Analysis
 {
     /// <summary>
     /// Defines a class that implements an extremum search.
+    /// </summary>
     /// <remarks>
     /// This class is a solution to the problem of finding the maximum and minimum points of the function F(x).
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Optimization
     {

--- a/sources/Analysis/Pade.cs
+++ b/sources/Analysis/Pade.cs
@@ -6,17 +6,17 @@ namespace UMapx.Analysis
 {
     /// <summary>
     /// Defines a Pade approximant.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Pad%C3%A9_approximant.
-    /// </remarks>
     /// Example: exp(x) = 1 + x + x^2/2! + x^3/3! + ...
     /// <code>
     /// float[] taylorExp = new float[] { 1.0f, 1.0f, 0.5f, 1.0f/6.0f, 1.0f/24.0f, 1.0f/120.0f, 1.0f/720.0f };
     /// var pade = new Pade(2, 2);
     /// var (n, d) = pade.Compute(taylorExp);
     /// </code>
-    /// </summary>
+    /// </remarks>
     [Serializable]
     public class Pade
     {

--- a/sources/Analysis/Roots.cs
+++ b/sources/Analysis/Roots.cs
@@ -6,11 +6,11 @@ namespace UMapx.Analysis
 {
     /// <summary>
     /// Defines a class for solving equations using the spectral decomposition of a matrix.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://www.mathworks.com/help/matlab/ref/roots.html
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Roots
     {

--- a/sources/Core/Complex32.cs
+++ b/sources/Core/Complex32.cs
@@ -397,10 +397,10 @@ namespace UMapx.Core
         #region Parsing
         /// <summary>
         /// Parses the string to complex number.
+        /// </summary>
         /// <remarks>
         /// Example: "1 + 2i", "0.321 + 11i", ".1i".
         /// </remarks>
-        /// </summary>
         /// <param name="s">Input string</param>
         /// <returns>Complex number</returns>
         public static Complex32 Parse(string s)

--- a/sources/Core/Kernel.cs
+++ b/sources/Core/Kernel.cs
@@ -4,11 +4,11 @@ namespace UMapx.Core
 {
     /// <summary>
     /// Used to work with kernel functions.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Kernel_(statistics)
     /// </remarks>
-    /// </summary>
     public static class Kernel
     {
         #region Bicubic kernel function

--- a/sources/Core/Maths.cs
+++ b/sources/Core/Maths.cs
@@ -1134,10 +1134,10 @@ namespace UMapx.Core
         #region Modular arithmetic and number theory
         /// <summary>
         /// Checks if number is prime.
+        /// </summary>
         /// <remarks>
         /// This method is based on enumerating all the divisors.
         /// </remarks>
-        /// </summary>
         /// <param name="p">Value</param>
         /// <returns>Boolean</returns>
         public static bool IsPrime(int p)
@@ -1161,10 +1161,10 @@ namespace UMapx.Core
         }
         /// <summary>
         /// Checks if number is prime.
+        /// </summary>
         /// <remarks>
         /// This method is based on enumerating all the divisors.
         /// </remarks>
-        /// </summary>
         /// <param name="p">Value</param>
         /// <returns>Boolean</returns>
         public static bool IsPrime(long p)
@@ -1667,11 +1667,11 @@ namespace UMapx.Core
 
         /// <summary>
         /// Implements a sieve for finding prime numbers.
+        /// </summary>
         /// <remarks>
         /// Recursive implementation of a memory-optimized segmented sieve of Eratosthenes. 
         /// The operational complexity of the O(N* logN) algorithm.The memory complexity is O(Δ), where Δ = sqrt(N).
         /// </remarks>
-        /// </summary>
         /// <param name="limit">Value</param>
         /// <returns>Array</returns>
         public static int[] Sieve(int limit)
@@ -1842,10 +1842,10 @@ namespace UMapx.Core
         #region Numeral components
         /// <summary>
         /// Returns a vector representing the decimal number in the given number system.
+        /// </summary>
         /// <remarks>
         /// Example: 10[10] = {1,0,1,0}[2].
         /// </remarks>
-        /// </summary>
         /// <param name="x">Byte</param>
         /// <param name="newbase">Base</param>
         /// <returns>Array</returns>
@@ -1866,10 +1866,10 @@ namespace UMapx.Core
         }
         /// <summary>
         /// Returns the decimal Number represented in decimal notation.
+        /// </summary>
         /// <remarks>
         /// Example: {1,0,1,0}[2] = 10[10].
         /// </remarks>
-        /// </summary>
         /// <param name="x">Array</param>
         /// <param name="thisbase">Base</param>
         /// <returns>Integer number</returns>
@@ -1887,10 +1887,10 @@ namespace UMapx.Core
         }
         /// <summary>
         /// Returns a number that interprets the specified vector in decimal.
+        /// </summary>
         /// <remarks>
         /// Example: {1,0,1,0}[2] = 1010[10].
         /// </remarks>
-        /// </summary>
         /// <param name="x">Array</param>
         /// <returns>Integer number</returns>
         public static long Vector2Numeral(int[] x)
@@ -1906,10 +1906,10 @@ namespace UMapx.Core
         }
         /// <summary>
         /// Returns a vector representing the decomposition of a decimal number into components.
+        /// </summary>
         /// <remarks>
         /// Example: 1010[10] = {1,0,1,0}[2]
         /// </remarks>
-        /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Array</returns>
         public static int[] Numeral2Vector(long x)

--- a/sources/Core/Matrice.cs
+++ b/sources/Core/Matrice.cs
@@ -11111,10 +11111,10 @@ namespace UMapx.Core
         #region Parse methods
         /// <summary>
         /// Parses the original string into a matrix of float numbers.
+        /// </summary>
         /// <remarks>
         /// Example: "[1, 2, 3; 4, 5, 6; 7, 8, 9]";
         /// </remarks>
-        /// </summary>
         /// <param name="a">Matrix</param>
         /// <param name="s">Input string</param>
         /// <returns>Matrix</returns>
@@ -11225,10 +11225,10 @@ namespace UMapx.Core
 
         /// <summary>
         /// Parses the original string into a vector of float numbers.
+        /// </summary>
         /// <remarks>
         /// Example: "[1, 2, 3, 4]";
         /// </remarks>
-        /// </summary>
         /// <param name="a">Matrix</param>
         /// <param name="s">Input string</param>
         /// <returns>Matrix</returns>
@@ -11278,10 +11278,10 @@ namespace UMapx.Core
         }
         /// <summary>
         /// Parses the original string into a vector of complex numbers.
+        /// </summary>
         /// <remarks>
         /// Example: "[1 + 2i, 2 + 0.3i, 3 + i, 4 - 11i]";
         /// </remarks>
-        /// </summary>
         /// <param name="a">Matrix</param>
         /// <param name="s">Input string</param>
         /// <returns>Matrix</returns>

--- a/sources/Core/Quaternion32.cs
+++ b/sources/Core/Quaternion32.cs
@@ -4,10 +4,10 @@ namespace UMapx.Core
 {
     /// <summary>
     /// Defines a quaternion.
+    /// </summary>
     /// <remarks>
     /// A quaternion is a system of hypercomplex numbers that forms a four-dimensional vector space over a field of real numbers.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public struct Quaternion32 : ICloneable
     {

--- a/sources/Core/Special.cs
+++ b/sources/Core/Special.cs
@@ -5,11 +5,11 @@ namespace UMapx.Core
 {
     /// <summary>
     /// Used to implement special mathematical functions.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Special_functions
     /// </remarks>
-    /// </summary>
     public static class Special
     {
         #region Private data
@@ -2642,12 +2642,12 @@ namespace UMapx.Core
         #region Hypergeometric function
         /// <summary>
         /// Returns the value of a hypergeometric function.
+        /// </summary>
         /// <remarks>
         /// This version of the hypergeometric function is found in the Russian literature and is indicated: F(a,b,c,z).
         /// More information can be found on the website:
         /// https://en.wikipedia.org/wiki/Hypergeometric_function
         /// </remarks>
-        /// </summary>
         /// <param name="a">Value</param>
         /// <param name="b">Value</param>
         /// <param name="c">Value</param>
@@ -2691,12 +2691,12 @@ namespace UMapx.Core
         }
         /// <summary>
         /// Returns the value of a hypergeometric function.
+        /// </summary>
         /// <remarks>
         /// This version of the hypergeometric function is found in the Russian literature and is indicated: F(a,b,c,z).
         /// More information can be found on the website:
         /// https://en.wikipedia.org/wiki/Hypergeometric_function
         /// </remarks>
-        /// </summary>
         /// <param name="a">Value</param>
         /// <param name="b">Value</param>
         /// <param name="c">Value</param>
@@ -2735,6 +2735,7 @@ namespace UMapx.Core
         }
         /// <summary>
         /// Returns the value of a hypergeometric function.
+        /// </summary>
         /// <remarks>
         /// The hypergeometric function can be used in several variations:
         /// F(a,b,z); F(a,~,z); F(~,b,z); F(~,~,z).
@@ -2742,7 +2743,6 @@ namespace UMapx.Core
         /// More information can be found on the website:
         /// https://www.mathworks.com/help/symbolic/hypergeom.html#bt1nkmw-2
         /// </remarks>
-        /// </summary>
         /// <param name="a">Value</param>
         /// <param name="b">Value</param>
         /// <param name="z">Value</param>
@@ -2817,6 +2817,7 @@ namespace UMapx.Core
         }
         /// <summary>
         /// Returns the value of a hypergeometric function.
+        /// </summary>
         /// <remarks>
         /// The hypergeometric function can be used in several variations:
         /// F(a,b,z); F(a,~,z); F(~,b,z); F(~,~,z).
@@ -2824,7 +2825,6 @@ namespace UMapx.Core
         /// More information can be found on the website:
         /// https://www.mathworks.com/help/symbolic/hypergeom.html#bt1nkmw-2
         /// </remarks>
-        /// </summary>
         /// <param name="a">Value</param>
         /// <param name="b">Value</param>
         /// <param name="z">Value</param>

--- a/sources/Core/StringOptions.cs
+++ b/sources/Core/StringOptions.cs
@@ -104,10 +104,10 @@ namespace UMapx.Core
         }
         /// <summary>
         /// Translates the original string to complex number.
+        /// </summary>
         /// <remarks>
         /// Example: "1 + 2i", "0.321 + 11i", ".1i".
         /// </remarks>
-        /// </summary>
         /// <param name="s">Input string</param>
         /// <returns>Text as a sequence of Unicode characters</returns>
         public static Complex32 Compar(string s)

--- a/sources/Decomposition/Arnoldi.cs
+++ b/sources/Decomposition/Arnoldi.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines Arnoldi transform.
+    /// </summary>
     /// <remarks>
     /// This transformation is used to reduce the square matrix to the Hessenberg form.
     /// The matrix A is represented as the product of three matrices: A = Q * H * Qᵀ, where H is the upper Hessenberg triangular matrix, Q is the orthogonal matrix.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Arnoldi_iteration
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Arnoldi
     {

--- a/sources/Decomposition/Bidiagonal.cs
+++ b/sources/Decomposition/Bidiagonal.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines bidiagonal decomposition.
+    /// </summary>
     /// <remarks>
     /// This is a representation of a matrix in the form A = U * B * Vᵀ, where U and V are orthogonal matrices
     /// obtained using Householder transformations and B is a bidiagonal matrix.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Bidiagonalization
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Bidiagonal
     {

--- a/sources/Decomposition/Cholesky.cs
+++ b/sources/Decomposition/Cholesky.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines Cholesky decomposition.
+    /// </summary>
     /// <remarks>
     /// This is a representation of a symmetric positive definite square matrix in the form of a product: A = L * Lᵀ, 
     /// where L is a lower triangular matrix with strictly positive elements on the diagonal.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Cholesky_decomposition
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Cholesky
     {

--- a/sources/Decomposition/Diagonal.cs
+++ b/sources/Decomposition/Diagonal.cs
@@ -5,11 +5,11 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines diagonal decomposition.
+    /// </summary>
     /// <remarks>
     /// This is a representation of the square matrix A as the product of two matrices: A = B * D, where B is the Square matrix and D is the diagonal matrix.
     /// This decomposition is used to highlight diagonal matrices in other decompositions (for example, LDU-, LDL-decompositions).
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Diagonal
     {

--- a/sources/Decomposition/EVD.cs
+++ b/sources/Decomposition/EVD.cs
@@ -5,6 +5,7 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines eigenvalue decomposition.
+    /// </summary>
     /// <remarks>
     /// The eigenvalue decomposition is the representation of the square matrix A in the form of the product of three matrices A = V * D * inv(V), 
     /// where V is the matrix of spectral vectors and D is the diagonal (generally complex) matrix of eigenvalues.
@@ -15,7 +16,6 @@ namespace UMapx.Decomposition
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Eigendecomposition_of_a_matrix
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class EVD
     {

--- a/sources/Decomposition/GEVD.cs
+++ b/sources/Decomposition/GEVD.cs
@@ -5,12 +5,12 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines generalized eigenvalue decomposition.
+    /// </summary>
     /// <remarks>
     /// It is the task of finding a vector of values of V such that the representation: A * V = B * V * D.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Eigendecomposition_of_a_matrix#Generalized_eigenvalue_problem
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class GEVD
     {

--- a/sources/Decomposition/GramSchmidt.cs
+++ b/sources/Decomposition/GramSchmidt.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines the Gram-Schmidt orthogonalization process.
+    /// </summary>
     /// <remarks>
     /// In mathematics, in particular linear algebra and numerical analysis, the Gram-Schmidt process is a method of orthonormalizing a set of vectors
     /// in the space of internal works. This procedure is actively used for orthogonalization of bases.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Gram%E2%80%93Schmidt_process
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class GramSchmidt
     {

--- a/sources/Decomposition/Hessenberg.cs
+++ b/sources/Decomposition/Hessenberg.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines decomposition with a cast to Hessenberg form.
+    /// </summary>
     /// <remarks>
     /// This is a representation of a square matrix in the form of a product of three matrices: A = P * H * Pᵀ, 
     /// where H is the Hessenberg form and P is the unitary matrix.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Hessenberg_matrix
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Hessenberg
     {

--- a/sources/Decomposition/Householder.cs
+++ b/sources/Decomposition/Householder.cs
@@ -5,6 +5,7 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines Householder transformation.
+    /// </summary>
     /// <remarks>
     /// This is a linear transformation H (u) of the vector space V, which describes its mapping with respect to the hyperplane,
     /// which passes through the origin. It was proposed in 1958 by the American mathematician Elston Scott Householder. 
@@ -17,7 +18,6 @@ namespace UMapx.Decomposition
     /// More information can be found on the website: 
     /// https://en.wikipedia.org/wiki/Householder_transformation
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Householder
     {

--- a/sources/Decomposition/LDL.cs
+++ b/sources/Decomposition/LDL.cs
@@ -5,6 +5,7 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines LDL decomposition.
+    /// </summary>
     /// <remarks>
     /// This is a representation of a symmetric positive definite square matrix in the form of a product of three matrices: A = L * D * Lᵀ, 
     /// where L is a lower triangular matrix with strictly positive elements on the diagonal,
@@ -12,7 +13,6 @@ namespace UMapx.Decomposition
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Cholesky_decomposition#LDL_decomposition_2
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LDL
     {

--- a/sources/Decomposition/LDU.cs
+++ b/sources/Decomposition/LDU.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines LDU decomposition.
+    /// </summary>
     /// <remarks>
     /// This is the representation of a square matrix A as the product of three matrices: A = L * D * U, 
     /// where L is the lower triangular matrix, D is the diagonal matrix, and U is the upper triangular matrix.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/LU_decomposition
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LDU
     {

--- a/sources/Decomposition/LQ.cs
+++ b/sources/Decomposition/LQ.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines LQ decomposition.
+    /// </summary>
     /// <remarks>
     /// This is the representation of a matrix in the form of a product of two matrices: A = L * Q, 
     /// where Q is a unitary (or orthogonal) matrix, and L is a lower triangular matrix.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/QR_decomposition
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LQ
     {

--- a/sources/Decomposition/LU.cs
+++ b/sources/Decomposition/LU.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines LU decomposition.
+    /// </summary>
     /// <remarks>
     /// This is a representation of the square matrix A as the product of two matrices: A = L * U, 
     /// where L is the lower triangular matrix, U is the upper triangular matrix.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/LU_decomposition
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LU
     {

--- a/sources/Decomposition/Lanczos.cs
+++ b/sources/Decomposition/Lanczos.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines Lanczos transform.
+    /// </summary>
     /// <remarks>
     /// This transformation is used to represent the symmetric matrix A as a product
     /// of three matrices: A = Q * T * Qᵀ, where T is a tridiagonal matrix, and Q is an orthogonal matrix.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Lanczos_algorithm
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Lanczos
     {

--- a/sources/Decomposition/NNMF.cs
+++ b/sources/Decomposition/NNMF.cs
@@ -5,12 +5,12 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines non-negative matrix factorization.
+    /// </summary>
     /// <remarks>
     /// This is a representation of a rectangular matrix A as the product of two matrices: A = W * H.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Non-negative_matrix_factorization
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class NNMF
     {

--- a/sources/Decomposition/Polar.cs
+++ b/sources/Decomposition/Polar.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines polar decomposition.
+    /// </summary>
     /// <remarks>
     /// This is a representation of a rectangular matrix A in the form of a product of two matrices: A = U * P, 
     /// where U is a unitary matrix, P is a positive definite matrix.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Polar_decomposition
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Polar
     {

--- a/sources/Decomposition/Power.cs
+++ b/sources/Decomposition/Power.cs
@@ -5,11 +5,11 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines power iteration.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Power_iteration
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Power
     {

--- a/sources/Decomposition/QL.cs
+++ b/sources/Decomposition/QL.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines the QL decomposition of a square matrix.
+    /// </summary>
     /// <remarks>
     /// This is a representation of a matrix in the form of a product of two matrices: A = Q * L, 
     /// where Q is a unitary (or orthogonal) matrix and L is a lower triangular matrix.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/QR_decomposition
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class QL
     {

--- a/sources/Decomposition/QR.cs
+++ b/sources/Decomposition/QR.cs
@@ -5,6 +5,7 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines QR decomposition.
+    /// </summary>
     /// <remarks>
     /// This is a matrix representation in the form of a product of two matrices: A = Q * R, 
     /// where Q is a unitary (or orthogonal) matrix, and R is an upper triangular matrix.
@@ -12,7 +13,6 @@ namespace UMapx.Decomposition
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/QR_decomposition
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class QR
     {

--- a/sources/Decomposition/QZ.cs
+++ b/sources/Decomposition/QZ.cs
@@ -5,6 +5,7 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines QZ decomposition (generalized Schur decomposition).
+    /// </summary>
     /// <remarks>
     /// This is a matrix representation for a pair of matrices A and B such that
     /// A = Q * S * Zᵀ and B = Q * T * Zᵀ, where Q and Z are orthogonal and
@@ -12,7 +13,6 @@ namespace UMapx.Decomposition
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/QZ_decomposition
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class QZ
     {

--- a/sources/Decomposition/RQ.cs
+++ b/sources/Decomposition/RQ.cs
@@ -5,6 +5,7 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines RQ decomposition.
+    /// </summary>
     /// <remarks>
     /// This is a matrix representation in the form of a product of two matrices: A = R * Q, 
     /// where Q is a unitary (or orthogonal) matrix, and R is an upper triangular matrix.
@@ -12,7 +13,6 @@ namespace UMapx.Decomposition
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/QR_decomposition
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class RQ
     {

--- a/sources/Decomposition/SVD.cs
+++ b/sources/Decomposition/SVD.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines singular value decomposition.
+    /// </summary>
     /// <remarks>
     /// This is a representation of a rectangular matrix A in the form of the product of three matrices A = U * S * Vᵀ, 
     /// where U are left vectors, V are right vectors, and S are singular values.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Singular_value_decomposition
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class SVD
     {
@@ -83,10 +83,10 @@ namespace UMapx.Decomposition
         }
         /// <summary>
         /// Gets the pseudoinverse matrix.
+        /// </summary>
         /// <remarks>
         /// NOT RECOMMENDED.
         /// </remarks>
-        /// </summary>
         public float[,] P
         {
             get

--- a/sources/Decomposition/Schur.cs
+++ b/sources/Decomposition/Schur.cs
@@ -5,13 +5,13 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines Schur decomposition.
+    /// </summary>
     /// <remarks>
     /// This is a representation of a square matrix in the form of a product of three matrices: A = Q * T * Qᵀ,
     /// where Q is a unitary matrix and T is a quasi upper triangular matrix (Schur form).
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Schur_decomposition
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Schur
     {

--- a/sources/Decomposition/UDL.cs
+++ b/sources/Decomposition/UDL.cs
@@ -5,12 +5,12 @@ namespace UMapx.Decomposition
 {
     /// <summary>
     /// Defines UDL decomposition.
+    /// </summary>
     /// <remarks>
     /// This is the representation of a symmetric square matrix as the product of three matrices: A = U * D * L, 
     /// where U is the upper triangular matrix, D is the diagonal matrix, and L is the lower triangular matrix.
     /// This decomposition is a specific form of Cholesky decomposition.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class UDL
     {

--- a/sources/Distribution/Arcsine.cs
+++ b/sources/Distribution/Arcsine.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the arcsine distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Arcsine_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Arcsine : IDistribution
     {

--- a/sources/Distribution/Bernoulli.cs
+++ b/sources/Distribution/Bernoulli.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the distribution of Bernoulli.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Bernoulli_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Bernoulli : IDistribution
     {

--- a/sources/Distribution/Beta.cs
+++ b/sources/Distribution/Beta.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the beta distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Beta_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Beta : IDistribution
     {

--- a/sources/Distribution/BetaPrime.cs
+++ b/sources/Distribution/BetaPrime.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the beta distribution of the second kind.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Beta_prime_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class BetaPrime : IDistribution
     {

--- a/sources/Distribution/Binomial.cs
+++ b/sources/Distribution/Binomial.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the binomial distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Binomial_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Binomial : IDistribution
     {

--- a/sources/Distribution/BirnbaumSaunders.cs
+++ b/sources/Distribution/BirnbaumSaunders.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Birnbaum-Saunders distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Birnbaum–Saunders_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class BirnbaumSaunders : IDistribution
     {

--- a/sources/Distribution/Burr.cs
+++ b/sources/Distribution/Burr.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Burr distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Burr_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Burr : IDistribution
     {

--- a/sources/Distribution/Cauchy.cs
+++ b/sources/Distribution/Cauchy.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Cauchy distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Cauchy_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Cauchy : IDistribution
     {

--- a/sources/Distribution/ChiSquare.cs
+++ b/sources/Distribution/ChiSquare.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the xi-square distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Chi-squared_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class ChiSquare : IDistribution
     {

--- a/sources/Distribution/ChoiWilliams.cs
+++ b/sources/Distribution/ChoiWilliams.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the distribution of Choi Williams.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Choi%E2%80%93Williams_distribution_function
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class ChoiWilliams : IDistribution
     {

--- a/sources/Distribution/ConeShape.cs
+++ b/sources/Distribution/ConeShape.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the distribution of the conical shape.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Cone-shape_distribution_function
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class ConeShape : IDistribution
     {

--- a/sources/Distribution/Erlang.cs
+++ b/sources/Distribution/Erlang.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the distribution of Erlang.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Erlang_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Erlang : IDistribution
     {

--- a/sources/Distribution/Exponential.cs
+++ b/sources/Distribution/Exponential.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the exponential distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Exponential_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Exponential : IDistribution
     {

--- a/sources/Distribution/FisherSnedecor.cs
+++ b/sources/Distribution/FisherSnedecor.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Fisher distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/F-distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FisherSnedecor : IDistribution
     {

--- a/sources/Distribution/FisherZ.cs
+++ b/sources/Distribution/FisherZ.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Fisher's Z-distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Fisher%27s_z-distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FisherZ : IDistribution
     {

--- a/sources/Distribution/Gamma.cs
+++ b/sources/Distribution/Gamma.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Gamma-distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Gamma_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Gamma : IDistribution
     {

--- a/sources/Distribution/Gaussian.cs
+++ b/sources/Distribution/Gaussian.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Gaussian distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Normal_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Gaussian : IDistribution
     {

--- a/sources/Distribution/Geometric.cs
+++ b/sources/Distribution/Geometric.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the geometric distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Geometric_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Geometric : IDistribution
     {

--- a/sources/Distribution/Gompertz.cs
+++ b/sources/Distribution/Gompertz.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Gompertz distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Gompertz_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Gompertz : IDistribution
     {

--- a/sources/Distribution/Gumbel.cs
+++ b/sources/Distribution/Gumbel.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Gumbel distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Gumbel_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Gumbel : IDistribution
     {

--- a/sources/Distribution/HyperbolicSecant.cs
+++ b/sources/Distribution/HyperbolicSecant.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the hyperbolic secant distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Hyperbolic_secant_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class HyperbolicSecant : IDistribution
     {

--- a/sources/Distribution/Hypergeometric.cs
+++ b/sources/Distribution/Hypergeometric.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the hypergeometric distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Hypergeometric_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Hypergeometric : IDistribution
     {

--- a/sources/Distribution/Kumaraswamy.cs
+++ b/sources/Distribution/Kumaraswamy.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the distribution of Kumaraswamy.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Kumaraswamy_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Kumaraswamy : IDistribution
     {

--- a/sources/Distribution/Laplace.cs
+++ b/sources/Distribution/Laplace.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Laplace distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Laplace_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Laplace : IDistribution
     {

--- a/sources/Distribution/Levy.cs
+++ b/sources/Distribution/Levy.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Levy distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/L%C3%A9vy_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Levy : IDistribution
     {

--- a/sources/Distribution/LogGaussian.cs
+++ b/sources/Distribution/LogGaussian.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the logarithmic Gaussian distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Log-normal_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LogGaussian : IDistribution
     {

--- a/sources/Distribution/LogLogistic.cs
+++ b/sources/Distribution/LogLogistic.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the log-logistic distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Log-logistic_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LogLogistic : IDistribution
     {

--- a/sources/Distribution/Logarithmic.cs
+++ b/sources/Distribution/Logarithmic.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the logarithmic distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Logarithmic_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Logarithmic : IDistribution
     {

--- a/sources/Distribution/Logistic.cs
+++ b/sources/Distribution/Logistic.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the logistic distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Logistic_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Logistic : IDistribution
     {

--- a/sources/Distribution/Nakagami.cs
+++ b/sources/Distribution/Nakagami.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the distribution of Nakagami.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Nakagami_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Nakagami : IDistribution
     {

--- a/sources/Distribution/Pareto.cs
+++ b/sources/Distribution/Pareto.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Pareto distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Pareto_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Pareto : IDistribution
     {

--- a/sources/Distribution/Poisson.cs
+++ b/sources/Distribution/Poisson.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Poisson distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Poisson_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Poisson : IDistribution
     {

--- a/sources/Distribution/Rademacher.cs
+++ b/sources/Distribution/Rademacher.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Rademacher distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Rademacher_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Rademacher : IDistribution
     {

--- a/sources/Distribution/Rayleigh.cs
+++ b/sources/Distribution/Rayleigh.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the logarithmic distribution of Rayleigh.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Rayleigh_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Rayleigh : IDistribution
     {

--- a/sources/Distribution/Student.cs
+++ b/sources/Distribution/Student.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Student's distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Student%27s_t-distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Student : IDistribution
     {

--- a/sources/Distribution/Triangular.cs
+++ b/sources/Distribution/Triangular.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the triangular distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Triangular_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Triangular : IDistribution
     {

--- a/sources/Distribution/UQuadratic.cs
+++ b/sources/Distribution/UQuadratic.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the U-quadratic distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/U-quadratic_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class UQuadratic : IDistribution
     {

--- a/sources/Distribution/Uniform.cs
+++ b/sources/Distribution/Uniform.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the uniform distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Uniform_distribution_(continuous)
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Uniform : IDistribution
     {

--- a/sources/Distribution/Weibull.cs
+++ b/sources/Distribution/Weibull.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Weibull distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Weibull_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Weibull : IDistribution
     {

--- a/sources/Distribution/Wigner.cs
+++ b/sources/Distribution/Wigner.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the Wigner semicircular distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wigner_semicircle_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Wigner : IDistribution
     {

--- a/sources/Distribution/WrappedCauchy.cs
+++ b/sources/Distribution/WrappedCauchy.cs
@@ -5,11 +5,11 @@ namespace UMapx.Distribution
 {
     /// <summary>
     /// Defines the compact Cauchy distribution.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wrapped_Cauchy_distribution
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class WrappedCauchy : IDistribution
     {

--- a/sources/Imaging/AdditiveNoise.cs
+++ b/sources/Imaging/AdditiveNoise.cs
@@ -7,11 +7,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the additive noise filter.
+    /// </summary>
     /// <remarks>
     /// Filter usage example:
     /// https://en.wikipedia.org/wiki/Gaussian_noise
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class AdditiveNoise : IBitmapFilter
     {

--- a/sources/Imaging/BlendMode.cs
+++ b/sources/Imaging/BlendMode.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Used to blending layers.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://www.pegtop.net/delphi/articles/blendmodes/index.htm
     /// </remarks>
-    /// </summary>
     public static class BlendMode
     {
         #region Blend mode components

--- a/sources/Imaging/BrightnessCorrection.cs
+++ b/sources/Imaging/BrightnessCorrection.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the brightness correction filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://esate.ru/uroki/OpenGL/image_processing/_p4106/
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class BrightnessCorrection : Correction, IBitmapFilter
     {

--- a/sources/Imaging/CLAHE.cs
+++ b/sources/Imaging/CLAHE.cs
@@ -9,11 +9,11 @@ namespace UMapx.Imaging
     /// <summary>
     /// Defines the Contrast Limited Adaptive Histogram Equalization (CLAHE).
     /// Operates in RGB by equalizing luminance (Rec.709) with bilinear interpolation between tile LUTs.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://uk.mathworks.com/help/visionhdl/ug/contrast-adaptive-histogram-equalization.html
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class CLAHE : IBitmapFilter
     {

--- a/sources/Imaging/CannyEdgeDetector.cs
+++ b/sources/Imaging/CannyEdgeDetector.cs
@@ -9,11 +9,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines a Canny edge detector.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Canny_edge_detector
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class CannyEdgeDetector : IBitmapFilter2, IBitmapFilter
     {

--- a/sources/Imaging/ContrastCorrection.cs
+++ b/sources/Imaging/ContrastCorrection.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the contrast correction filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://esate.ru/uroki/OpenGL/image_processing/_p4106/
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class ContrastCorrection : Correction, IBitmapFilter
     {

--- a/sources/Imaging/ErrorDiffusionDithering.cs
+++ b/sources/Imaging/ErrorDiffusionDithering.cs
@@ -7,11 +7,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the error diffusion dithering filter.
+    /// </summary>
     /// <remarks>
     /// Filter usage example:
     /// https://en.wikipedia.org/wiki/Dither
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class ErrorDiffusionDithering : Rebuilder, IBitmapFilter
     {

--- a/sources/Imaging/ExposureCorrection.cs
+++ b/sources/Imaging/ExposureCorrection.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the exposure correction filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Exposure_(photography)
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class ExposureCorrection : Correction, IBitmapFilter
     {

--- a/sources/Imaging/ExposureFusion.cs
+++ b/sources/Imaging/ExposureFusion.cs
@@ -8,11 +8,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the exposure fusion filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://web.stanford.edu/class/cs231m/project-1/exposure-fusion.pdf
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class ExposureFusion
     {

--- a/sources/Imaging/FlatFieldCorrection.cs
+++ b/sources/Imaging/FlatFieldCorrection.cs
@@ -8,11 +8,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the flat-field correction filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://imagej.net/Image_Intensity_Processing
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FlatFieldCorrection : IBitmapFilter2, IBitmapFilter
     {

--- a/sources/Imaging/FreiChen.cs
+++ b/sources/Imaging/FreiChen.cs
@@ -8,11 +8,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines Frei-Chen convolution filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Frei-Chen_operator
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FreiChen : IBitmapFilter2, IBitmapFilter
     {

--- a/sources/Imaging/GammaCorrection.cs
+++ b/sources/Imaging/GammaCorrection.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the gamma correction filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Gamma_correction
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class GammaCorrection : Correction, IBitmapFilter
     {

--- a/sources/Imaging/GaussianBlur.cs
+++ b/sources/Imaging/GaussianBlur.cs
@@ -8,10 +8,10 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the Gaussian blur filter.
+    /// </summary>
     /// <remarks>
     /// This is a very fast pseudo-Gaussian blur filter via N separable box filters (default 3).
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class GaussianBlur : IBitmapFilter2, IBitmapFilter
     {

--- a/sources/Imaging/Grid.cs
+++ b/sources/Imaging/Grid.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the grid filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://www.codeproject.com/Articles/2122/Image-Processing-for-Dummies-with-C-and-GDI-Part
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Grid : PointAddition, IBitmapFilter2
     {

--- a/sources/Imaging/HSBGrayscale.cs
+++ b/sources/Imaging/HSBGrayscale.cs
@@ -9,10 +9,10 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the grayscale filter based on the HSB structure.
+    /// </summary>
     /// <remarks>
     /// The filter discolors the specified part of the image.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class HSBGrayscale : IBitmapFilter
     {

--- a/sources/Imaging/HSLGrayscale.cs
+++ b/sources/Imaging/HSLGrayscale.cs
@@ -9,10 +9,10 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the grayscale filter based on the HSL structure.
+    /// </summary>
     /// <remarks>
     /// The filter discolors the specified part of the image.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class HSLGrayscale : IBitmapFilter
     {

--- a/sources/Imaging/HistogramEqualization.cs
+++ b/sources/Imaging/HistogramEqualization.cs
@@ -7,11 +7,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the global histogram equalization filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://www.cromwell-intl.com/3d/histogram/
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class HistogramEqualization : IBitmapFilter
     {

--- a/sources/Imaging/HomomorphicEnhancement.cs
+++ b/sources/Imaging/HomomorphicEnhancement.cs
@@ -5,6 +5,7 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the filter for homomorphic processing.
+    /// </summary>
     /// <remarks>
     /// A homomorphic filter is most often used to equalize the illumination of images.
     /// It simultaneously normalizes the brightness of the image and increases the contrast.
@@ -12,7 +13,6 @@ namespace UMapx.Imaging
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Homomorphic_filtering
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class HomomorphicEnhancement : LocalCorrection, IBitmapFilter2
     {

--- a/sources/Imaging/Jitter.cs
+++ b/sources/Imaging/Jitter.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the jitter filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://www.codeproject.com/Articles/2122/Image-Processing-for-Dummies-with-C-and-GDI-Part
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Jitter : PointAddition, IBitmapFilter2
     {

--- a/sources/Imaging/Kuwahara.cs
+++ b/sources/Imaging/Kuwahara.cs
@@ -8,11 +8,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the Kuwahara filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Kuwahara_filter
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Kuwahara : IBitmapFilter2, IBitmapFilter
     {

--- a/sources/Imaging/LevelsCorrection.cs
+++ b/sources/Imaging/LevelsCorrection.cs
@@ -5,11 +5,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the levels correction filter.
+    /// </summary>
     /// <remarks>
     /// Filter usage example:
     /// https://digital-photography-school.com/using-levels-photoshop-image-correct-color-contrast/
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LevelsCorrection : Correction, IBitmapFilter
     {

--- a/sources/Imaging/LocalContrastEnhancement.cs
+++ b/sources/Imaging/LocalContrastEnhancement.cs
@@ -5,6 +5,7 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the local contrast enhancement filter.
+    /// </summary>
     /// <remarks>
     /// This filter is also known as "Unsharp Masking."
     /// More information can be found on the website:
@@ -12,7 +13,6 @@ namespace UMapx.Imaging
     /// Filter usage example:
     /// http://www.knowhowtransfer.com/photoshop-professional-plugins/alce-local-contrast-enhancer/
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LocalContrastEnhancement : LocalCorrection, IBitmapFilter2
     {

--- a/sources/Imaging/LocalContrastInversion.cs
+++ b/sources/Imaging/LocalContrastInversion.cs
@@ -5,10 +5,10 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the local contrast inversion filter.
+    /// </summary>
     /// <remarks>
     /// This filter is used to equalize the illumination of images by averaging the brightness.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LocalContrastInversion : LocalCorrection, IBitmapFilter2
     {

--- a/sources/Imaging/LocalHistogramEqualization.cs
+++ b/sources/Imaging/LocalHistogramEqualization.cs
@@ -8,11 +8,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the local histogram equalization filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://angeljohnsy.blogspot.com/2011/06/local-histogram-equalization.html
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LocalHistogramEqualization : IBitmapFilter2, IBitmapFilter
     {

--- a/sources/Imaging/LocalHistogramStretch.cs
+++ b/sources/Imaging/LocalHistogramStretch.cs
@@ -9,11 +9,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the local histogram stretch filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://www.academia.edu/7629047/Image_enhancement_by_local_histogram_stretching
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LocalHistogramStretch : IBitmapFilter
     {

--- a/sources/Imaging/LocalThreshold.cs
+++ b/sources/Imaging/LocalThreshold.cs
@@ -5,11 +5,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the Bradley local threshold filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://www.scs.carleton.ca/~roth/iit-publications-iti/docs/gerh-50002.pdf
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LocalThreshold : LocalCorrection, IBitmapFilter2
     {

--- a/sources/Imaging/Morphology.cs
+++ b/sources/Imaging/Morphology.cs
@@ -8,11 +8,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the morphology filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Mathematical_morphology
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Morphology : IBitmapFilter2, IBitmapFilter
     {

--- a/sources/Imaging/MotionDetector.cs
+++ b/sources/Imaging/MotionDetector.cs
@@ -8,10 +8,10 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the motion detector.
+    /// </summary>
     /// <remarks>
     /// Implements IDisposable interface.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class MotionDetector : IDisposable
     {

--- a/sources/Imaging/Noise.cs
+++ b/sources/Imaging/Noise.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the noise filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://www.codeproject.com/Articles/2122/Image-Processing-for-Dummies-with-C-and-GDI-Part
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Noise : PointMultiplication, IBitmapFilter2
     {

--- a/sources/Imaging/NormalBump.cs
+++ b/sources/Imaging/NormalBump.cs
@@ -6,11 +6,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines a normal bump filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Normal_mapping
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class NormalBump : IBitmapFilter2, IBitmapFilter
     {

--- a/sources/Imaging/OilPainting.cs
+++ b/sources/Imaging/OilPainting.cs
@@ -8,11 +8,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the oil painting filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://www.codeproject.com/articles/471994/oilpainteffect
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class OilPainting : IBitmapFilter2, IBitmapFilter
     {

--- a/sources/Imaging/Operation.cs
+++ b/sources/Imaging/Operation.cs
@@ -7,11 +7,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the linear operation filter.
+    /// </summary>
     /// <remarks>
     /// This filter works by applying the following algorithm: C (x, y) = a * A (x, y) + b * B (x, y), where A, B are the original images,
     /// a, b are the coefficients.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Operation : IBitmapFilter2
     {

--- a/sources/Imaging/PerlinNoise.cs
+++ b/sources/Imaging/PerlinNoise.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the Perlin noise.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Perlin_noise
     /// </remarks>
-    /// </summary>
     public class PerlinNoise
     {
         #region Private data

--- a/sources/Imaging/Pixelate.cs
+++ b/sources/Imaging/Pixelate.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the pixelation filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://www.codeproject.com/Articles/2122/Image-Processing-for-Dummies-with-C-and-GDI-Part
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Pixelate : PointAddition, IBitmapFilter2
     {

--- a/sources/Imaging/Quantization.cs
+++ b/sources/Imaging/Quantization.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the quantization filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://en.wikipedia.org/wiki/Posterization
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Quantization : Correction, IBitmapFilter
     {

--- a/sources/Imaging/SaltAndPepper.cs
+++ b/sources/Imaging/SaltAndPepper.cs
@@ -6,11 +6,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the salt and pepper noise filter.
+    /// </summary>
     /// <remarks>
     /// Filter usage example:
     /// https://en.wikipedia.org/wiki/Salt-and-pepper_noise
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class SaltAndPepper : IBitmapFilter
     {

--- a/sources/Imaging/ShadowsHighlightsCorrection.cs
+++ b/sources/Imaging/ShadowsHighlightsCorrection.cs
@@ -5,12 +5,12 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the shadows and lights correction filter.
+    /// </summary>
     /// <remarks>
     /// Shadow-Highlights correction is used to correct unevenly lit images. Unlike other local algorithms
     /// (for example, Single Scale Retinex, Homomorphic Enhancement, Flat-Field Correction) filter allows you to adjust the brightness values separately in dark and bright areas
     /// Images.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class ShadowsHighlightsCorrection : LocalCorrection, IBitmapFilter2
     {

--- a/sources/Imaging/SingleScaleRetinex.cs
+++ b/sources/Imaging/SingleScaleRetinex.cs
@@ -5,11 +5,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the Single Scale Retinex filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://dragon.larc.nasa.gov/background/pubabs/papers/gspx1.pdf
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class SingleScaleRetinex : LocalCorrection, IBitmapFilter2
     {

--- a/sources/Imaging/StereoAnaglyph.cs
+++ b/sources/Imaging/StereoAnaglyph.cs
@@ -6,11 +6,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the stereo effect filter for a pair of images.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://www.3dtv.at/Knowhow/AnaglyphComparison_en.aspx
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class StereoAnaglyph : IBitmapFilter2
     {

--- a/sources/Imaging/StereoDisparity.cs
+++ b/sources/Imaging/StereoDisparity.cs
@@ -7,11 +7,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the stereo disparity filter for a pair of images.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://docs.opencv.org/master/d3/d14/tutorial_ximgproc_disparity_filtering.html
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class StereoDisparity
     {

--- a/sources/Imaging/TemperatureCorrection.cs
+++ b/sources/Imaging/TemperatureCorrection.cs
@@ -5,10 +5,10 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the temperature correction filter.
+    /// </summary>
     /// <remarks>
     /// The filter uses an approximation of the Planck curve.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class TemperatureCorrection : PhotoFilter, IBitmapFilter
     {

--- a/sources/Imaging/ToneDiffusionDithering.cs
+++ b/sources/Imaging/ToneDiffusionDithering.cs
@@ -6,11 +6,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the tone diffusion dithering filter.
+    /// </summary>
     /// <remarks>
     /// Filter usage example:
     /// https://en.wikipedia.org/wiki/Dither
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class ToneDiffusionDithering : IBitmapFilter
     {
@@ -90,13 +90,13 @@ namespace UMapx.Imaging
         private static readonly Random rand = new Random();
         /// <summary>
         /// Initializes the order dithering filter.
+        /// </summary>
         /// <remarks>
         /// More information can be found on the website:
         /// http://en.wikipedia.org/wiki/Ordered_dithering
         /// Filter usage example:
         /// https://en.wikipedia.org/wiki/Dither
         /// </remarks>
-        /// </summary>
         /// <param name="radius">Radius [0, 255]</param>
         /// <returns>Tone diffusion dithering filter</returns>
         public static ToneDiffusionDithering Order(int radius)

--- a/sources/Imaging/Water.cs
+++ b/sources/Imaging/Water.cs
@@ -4,11 +4,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the water filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://www.codeproject.com/Articles/2122/Image-Processing-for-Dummies-with-C-and-GDI-Part
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Water : PointMultiplication, IBitmapFilter2
     {

--- a/sources/Imaging/Wiener.cs
+++ b/sources/Imaging/Wiener.cs
@@ -8,11 +8,11 @@ namespace UMapx.Imaging
 {
     /// <summary>
     /// Defines the Wiener filter for local noise reduction.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wiener_filter
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class Wiener : IBitmapFilter2, IBitmapFilter
     {

--- a/sources/Response/FIR.cs
+++ b/sources/Response/FIR.cs
@@ -5,13 +5,13 @@ namespace UMapx.Response
 {
     /// <summary>
     /// Defines a filter with a finite impulse response.
+    /// </summary>
     /// <remarks>
     /// A filter with a finite impulse response (transverse filter, FIR filter or FIR filter) is one of the types of linear
     /// digital filters, a characteristic feature of which is the limited time of its impulse response
     /// (from some point in time it becomes exactly equal to zero). Such a filter is also called non-recursive due to the lack of feedback.
     /// The denominator of the transfer function of such a filter is a certain constant.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FIR : IResponse
     {

--- a/sources/Response/IIR.cs
+++ b/sources/Response/IIR.cs
@@ -5,13 +5,13 @@ namespace UMapx.Response
 {
     /// <summary>
     /// Defines a filter with an infinite impulse response.
+    /// </summary>
     /// <remarks>
     /// Filter with infinite impulse response (recursive filter, IIR filter or IIR filter) - a linear electronic filter,
     /// using one or more of its outputs as an input, i.e. forms a feedback. The main property of such filters
     /// is that their impulse response is of infinite length in the time domain, and the transfer function
     /// has a fractional rational look.
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class IIR : IResponse
     {

--- a/sources/Transform/BilateralFilter.cs
+++ b/sources/Transform/BilateralFilter.cs
@@ -6,12 +6,12 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the bilateral filter.
+    /// </summary>
     /// <remarks>
     /// Optimized implementation.
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Bilateral_filter
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class BilateralFilter : IFilter
     {

--- a/sources/Transform/BilateralGridFilter.cs
+++ b/sources/Transform/BilateralGridFilter.cs
@@ -5,12 +5,12 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the bilateral filter.
+    /// </summary>
     /// <remarks>
     /// Fast implementation of the bilateral filter (real-time).
     /// More information can be found on the website:
     /// https://www.researchgate.net/publication/220184523_Real-time_edge-aware_image_processing_with_the_bilateral_grid
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class BilateralGridFilter : IFilter
     {

--- a/sources/Transform/CosineTransform.cs
+++ b/sources/Transform/CosineTransform.cs
@@ -5,11 +5,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the cosine transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Discrete_cosine_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class CosineTransform : ITransform
     {

--- a/sources/Transform/DeltaTransform.cs
+++ b/sources/Transform/DeltaTransform.cs
@@ -6,11 +6,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the delta transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Delta_encoding
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class DeltaTransform : ITransform
     {

--- a/sources/Transform/DomainTransformFilter.cs
+++ b/sources/Transform/DomainTransformFilter.cs
@@ -5,12 +5,12 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the domain transform filter.
+    /// </summary>
     /// <remarks>
     /// This filter is a computationally effective analogue of a bilateral filter.
     /// More information can be found on the website:
     /// http://www.inf.ufrgs.br/~eslgastal/DomainTransform/Gastal_Oliveira_SIGGRAPH2011_Domain_Transform.pdf
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class DomainTransformFilter : IFilter
     {

--- a/sources/Transform/FastCosineTransform.cs
+++ b/sources/Transform/FastCosineTransform.cs
@@ -6,11 +6,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the fast cosine transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Discrete_cosine_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FastCosineTransform : ITransform
     {

--- a/sources/Transform/FastFourierTransform.cs
+++ b/sources/Transform/FastFourierTransform.cs
@@ -6,12 +6,12 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the fast Fourier transform using the Cooley-Tukey and Bluestein algorithms.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Cooley%E2%80%93Tukey_FFT_algorithm
     /// https://en.wikipedia.org/wiki/Chirp_Z-transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FastFourierTransform : ITransform
     {

--- a/sources/Transform/FastHartleyTransform.cs
+++ b/sources/Transform/FastHartleyTransform.cs
@@ -6,11 +6,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the fast Hartley transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Discrete_Hartley_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FastHartleyTransform : ITransform
     {

--- a/sources/Transform/FastHilbertTransform.cs
+++ b/sources/Transform/FastHilbertTransform.cs
@@ -6,13 +6,13 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the fast Hilbert transform.
+    /// </summary>
     /// <remarks>
     /// NOT RECOMMENDED.
     /// 
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Hilbert_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FastHilbertTransform : ITransform
     {

--- a/sources/Transform/FastLaplaceTransform.cs
+++ b/sources/Transform/FastLaplaceTransform.cs
@@ -6,11 +6,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the fast Laplace transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Laplace_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FastLaplaceTransform : ITransform
     {
@@ -44,10 +44,10 @@ namespace UMapx.Transform
         }
         /// <summary>
         /// Gets or sets the damping factor (0, 1).
+        /// </summary>
         /// <remarks>
         /// If σ = 0, then the Laplace transform takes the form of a Fourier transform.
         /// </remarks>
-        /// </summary>
         public float Sigma
         {
             get

--- a/sources/Transform/FastSineTransform.cs
+++ b/sources/Transform/FastSineTransform.cs
@@ -7,6 +7,7 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the fast sine transform.
+    /// </summary>
     /// <remarks>
     /// NOT RECOMMENDED.
     /// This algorithm is less effective than the fast cosine transform.
@@ -14,7 +15,6 @@ namespace UMapx.Transform
     /// More information can be found on the website:
     /// http://sernam.ru/book_prett1.php?id=91
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FastSineTransform : ITransform
     {

--- a/sources/Transform/FastWalshHadamardTransform.cs
+++ b/sources/Transform/FastWalshHadamardTransform.cs
@@ -6,11 +6,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the fast Walsh-Hadamard transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://www.mathworks.com/matlabcentral/fileexchange/6879-fast-walsh-hadamard-transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FastWalshHadamardTransform : ITransform
     {

--- a/sources/Transform/FourierTransform.cs
+++ b/sources/Transform/FourierTransform.cs
@@ -5,11 +5,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the Fourier transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Discrete_Fourier_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FourierTransform : ITransform
     {

--- a/sources/Transform/GaussianPyramidTransform.cs
+++ b/sources/Transform/GaussianPyramidTransform.cs
@@ -5,11 +5,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the Gaussian pyramid transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://www.cs.toronto.edu/~jepson/csc320/notes/pyramids.pdf
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class GaussianPyramidTransform : IPyramidTransform
     {

--- a/sources/Transform/GuidedFilter.cs
+++ b/sources/Transform/GuidedFilter.cs
@@ -5,12 +5,12 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the guided filter.
+    /// </summary>
     /// <remarks>
     /// This filter is a computationally effective analogue of a bilateral filter.
     /// More information can be found on the website:
     /// http://kaiminghe.com/eccv10/index.html
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class GuidedFilter : IFilter
     {
@@ -49,10 +49,10 @@ namespace UMapx.Transform
         }
         /// <summary>
         /// Gets or sets the value of the epsilon (0, 1).
+        /// </summary>
         /// <remarks>
         /// Optimal value ε = 0.025.
         /// </remarks>
-        /// </summary>
         public float Eps
         {
             get

--- a/sources/Transform/HankelTransform.cs
+++ b/sources/Transform/HankelTransform.cs
@@ -5,6 +5,7 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the Hankel transform.
+    /// </summary>
     /// <remarks>
     /// NOT RECOMMENDED.
     /// There is no fast O(N log N) algorithm for this transform.
@@ -12,7 +13,6 @@ namespace UMapx.Transform
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Hankel_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class HankelTransform : ITransform
     {

--- a/sources/Transform/HartleyTransform.cs
+++ b/sources/Transform/HartleyTransform.cs
@@ -5,11 +5,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the Hartley transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Discrete_Hartley_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class HartleyTransform : ITransform
     {

--- a/sources/Transform/HilbertTransform.cs
+++ b/sources/Transform/HilbertTransform.cs
@@ -6,13 +6,13 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the Hilbert transform.
+    /// </summary>
     /// <remarks>
     /// NOT RECOMMENDED.
     /// 
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Hilbert_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class HilbertTransform : ITransform
     {

--- a/sources/Transform/LaplaceTransform.cs
+++ b/sources/Transform/LaplaceTransform.cs
@@ -5,11 +5,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the Laplace transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Laplace_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LaplaceTransform : ITransform
     {
@@ -43,10 +43,10 @@ namespace UMapx.Transform
         }
         /// <summary>
         /// Gets or sets the damping factor (0, 1).
+        /// </summary>
         /// <remarks>
         /// If σ = 0, then the Laplace transform takes the form of a Fourier transform.
         /// </remarks>
-        /// </summary>
         public float Sigma
         {
             get

--- a/sources/Transform/LaplacianPyramidFilter.cs
+++ b/sources/Transform/LaplacianPyramidFilter.cs
@@ -5,11 +5,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the Laplace pyramid filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://www.cs.toronto.edu/~jepson/csc320/notes/pyramids.pdf
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LaplacianPyramidFilter : IFilter
     {

--- a/sources/Transform/LaplacianPyramidTransform.cs
+++ b/sources/Transform/LaplacianPyramidTransform.cs
@@ -5,11 +5,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the Laplacian pyramid transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://www.cs.toronto.edu/~jepson/csc320/notes/pyramids.pdf
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LaplacianPyramidTransform : IPyramidTransform
     {

--- a/sources/Transform/LocalLaplacianFilter.cs
+++ b/sources/Transform/LocalLaplacianFilter.cs
@@ -5,11 +5,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the local Laplace pyramid filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://people.csail.mit.edu/sparis/publi/2011/siggraph/
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class LocalLaplacianFilter : IFilter
     {

--- a/sources/Transform/SineTransform.cs
+++ b/sources/Transform/SineTransform.cs
@@ -5,11 +5,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the sine transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://sernam.ru/book_prett1.php?id=91
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class SineTransform : ITransform
     {

--- a/sources/Transform/WalshHadamardTransform.cs
+++ b/sources/Transform/WalshHadamardTransform.cs
@@ -5,11 +5,11 @@ namespace UMapx.Transform
 {
     /// <summary>
     /// Defines the Walsh-Hadamard transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// http://kibia.ru/teachers/kreindelin/pdf/2.pdf
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class WalshHadamardTransform : ITransform
     {

--- a/sources/Wavelet/Discrete/WaveletPack.BattleLemarie.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.BattleLemarie.cs
@@ -4,11 +4,11 @@ namespace UMapx.Wavelet
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Battle-Lemarie wavelets

--- a/sources/Wavelet/Discrete/WaveletPack.Beylkin.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.Beylkin.cs
@@ -2,11 +2,11 @@
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Beylkin wavelet

--- a/sources/Wavelet/Discrete/WaveletPack.Bior.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.Bior.cs
@@ -2,20 +2,20 @@
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Biorthogonal wavelets
         /// <summary>
         /// Returns a biorthogonal wavelet 1.1.
+        /// </summary>
         /// <remarks>
         /// Haar wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack Bior11
         {
             get

--- a/sources/Wavelet/Discrete/WaveletPack.CDF.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.CDF.cs
@@ -2,11 +2,11 @@
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Cohen-Daubechies-Feaveau wavelets

--- a/sources/Wavelet/Discrete/WaveletPack.Coiflet.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.Coiflet.cs
@@ -2,11 +2,11 @@
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Coiflets wavelets

--- a/sources/Wavelet/Discrete/WaveletPack.Daubechie.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.Daubechie.cs
@@ -2,20 +2,20 @@
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Daubechies wavelets
         /// <summary>
         /// Returns Daubechies wavelet of 1 order.
+        /// </summary>
         /// <remarks>
         /// Haar wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack D1
         {
             get

--- a/sources/Wavelet/Discrete/WaveletPack.Fbsp.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.Fbsp.cs
@@ -2,20 +2,20 @@
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Fbsp wavelets
         /// <summary>
         /// Returns B-spline wavelet 1-0-0.
+        /// </summary>
         /// <remarks>
         /// Haar wavelet (delayed).
         /// </remarks>
-        /// </summary>
         public static WaveletPack Fbsp100
         {
             get

--- a/sources/Wavelet/Discrete/WaveletPack.FejerKorovkin.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.FejerKorovkin.cs
@@ -2,11 +2,11 @@
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Fejer-Korovkin wavelets

--- a/sources/Wavelet/Discrete/WaveletPack.GaborZak.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.GaborZak.cs
@@ -6,11 +6,11 @@ namespace UMapx.Wavelet
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Gabor-Zak wavelets

--- a/sources/Wavelet/Discrete/WaveletPack.Haar.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.Haar.cs
@@ -2,11 +2,11 @@
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Haar wavelet

--- a/sources/Wavelet/Discrete/WaveletPack.Kravchenko.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.Kravchenko.cs
@@ -4,11 +4,11 @@ namespace UMapx.Wavelet
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Kravchenko wavelet

--- a/sources/Wavelet/Discrete/WaveletPack.Legendre.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.Legendre.cs
@@ -2,20 +2,20 @@
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Legendre wavelets
         /// <summary>
         /// Returns Legendre wavelet of 1 order.
+        /// </summary>
         /// <remarks>
         /// Haar wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack L1
         {
             get
@@ -26,10 +26,10 @@
         }
         /// <summary>
         /// Returns Legendre wavelet of 2 order.
+        /// </summary>
         /// <remarks>
         /// Nonorthogonal wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack L2
         {
             get
@@ -39,10 +39,10 @@
         }
         /// <summary>
         /// Returns Legendre wavelet of 3 order.
+        /// </summary>
         /// <remarks>
         /// Nonorthogonal wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack L3
         {
             get
@@ -52,10 +52,10 @@
         }
         /// <summary>
         /// Returns Legendre wavelet of 4 order.
+        /// </summary>
         /// <remarks>
         /// Nonorthogonal wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack L4
         {
             get
@@ -73,10 +73,10 @@
         }
         /// <summary>
         /// Returns Legendre wavelet of 5 order.
+        /// </summary>
         /// <remarks>
         /// Nonorthogonal wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack L5
         {
             get
@@ -96,10 +96,10 @@
         }
         /// <summary>
         /// Returns Legendre wavelet of 6 order.
+        /// </summary>
         /// <remarks>
         /// Nonorthogonal wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack L6
         {
             get
@@ -125,10 +125,10 @@
         }
         /// <summary>
         /// Returns Legendre wavelet of 7 order.
+        /// </summary>
         /// <remarks>
         /// Nonorthogonal wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack L7
         {
             get
@@ -155,10 +155,10 @@
         }
         /// <summary>
         /// Returns Legendre wavelet of 8 order.
+        /// </summary>
         /// <remarks>
         /// Nonorthogonal wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack L8
         {
             get
@@ -187,10 +187,10 @@
         }
         /// <summary>
         /// Returns Legendre wavelet of 9 order.
+        /// </summary>
         /// <remarks>
         /// Nonorthogonal wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack L9
         {
             get

--- a/sources/Wavelet/Discrete/WaveletPack.Meyer.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.Meyer.cs
@@ -4,11 +4,11 @@ namespace UMapx.Wavelet
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Meyer wavelet

--- a/sources/Wavelet/Discrete/WaveletPack.Symlet.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.Symlet.cs
@@ -2,20 +2,20 @@
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Symlets wavelets
         /// <summary>
         /// Returns wavelet symlet of 1 order.
+        /// </summary>
         /// <remarks>
         /// Haar wavelet.
         /// </remarks>
-        /// </summary>
         public static WaveletPack S1
         {
             get

--- a/sources/Wavelet/Discrete/WaveletPack.Vaidyanathan.cs
+++ b/sources/Wavelet/Discrete/WaveletPack.Vaidyanathan.cs
@@ -2,11 +2,11 @@
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     public partial class WaveletPack
     {
         #region Vaidyanathan wavelet

--- a/sources/Wavelet/EdgeAvoidingWaveletDecomposition.cs
+++ b/sources/Wavelet/EdgeAvoidingWaveletDecomposition.cs
@@ -6,11 +6,11 @@ namespace UMapx.Wavelet
 {
     /// <summary>
     /// Defines the edge-avoiding wavelet decomposition.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://www.cs.huji.ac.il/w~raananf/projects/eaw/
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class EdgeAvoidingWaveletDecomposition : IPyramidTransform
     {

--- a/sources/Wavelet/EdgeAvoidingWaveletFilter.cs
+++ b/sources/Wavelet/EdgeAvoidingWaveletFilter.cs
@@ -6,11 +6,11 @@ namespace UMapx.Wavelet
 {
     /// <summary>
     /// Defines the edge-avoiding wavelet filter.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://www.cs.huji.ac.il/w~raananf/projects/eaw/
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class EdgeAvoidingWaveletFilter : IFilter
     {

--- a/sources/Wavelet/WaveletDecomposition.cs
+++ b/sources/Wavelet/WaveletDecomposition.cs
@@ -6,13 +6,13 @@ namespace UMapx.Wavelet
 {
     /// <summary>
     /// Defines a discrete wavelet decomposition.
+    /// </summary>
     /// <remarks>
     /// For the correct wavelet transform of a signal, it is necessary that its dimension be a power of 2.
     /// 
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Discrete_wavelet_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class WaveletDecomposition : IPyramidTransform
     {

--- a/sources/Wavelet/WaveletFilter.cs
+++ b/sources/Wavelet/WaveletFilter.cs
@@ -6,11 +6,11 @@ namespace UMapx.Wavelet
 {
     /// <summary>
     /// Defines the wavelet filter.
+    /// </summary>
     /// <remarks>
     /// For the correct wavelet transform of a signal, it is necessary that its dimension be a power of 2.
     /// It is recommended to use Coiflets (C1, C2, C3, C4 and C5).
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class WaveletFilter : IFilter
     {

--- a/sources/Wavelet/WaveletPack.cs
+++ b/sources/Wavelet/WaveletPack.cs
@@ -6,11 +6,11 @@ namespace UMapx.Wavelet
 {
     /// <summary>
     /// Defines the discrete wavelet.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Wavelet
     /// </remarks>
-    /// </summary>
     [Serializable]
     public partial class WaveletPack : ICloneable, ISerializable
     {

--- a/sources/Wavelet/WaveletTransform.cs
+++ b/sources/Wavelet/WaveletTransform.cs
@@ -6,13 +6,13 @@ namespace UMapx.Wavelet
 {
     /// <summary>
     /// Defines a discrete wavelet transform.
+    /// </summary>
     /// <remarks>
     /// For the correct wavelet transform of a signal, it is necessary that its dimension be a power of 2.
     /// 
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Discrete_wavelet_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class WaveletTransform : IWaveletTransform, ITransform
     {

--- a/sources/Window/FastRealWeylHeisenbergTransform.cs
+++ b/sources/Window/FastRealWeylHeisenbergTransform.cs
@@ -7,11 +7,11 @@ namespace UMapx.Window
 {
     /// <summary>
     /// Defines fast real Weyl-Heisenberg transform.
+    /// </summary>
     /// <remarks>
     /// The class represents a computationally efficient implementation of one-dimensional and two-dimensional discrete real orthogonal
     /// Weyl-Heisenberg transforms. This implementation was designed and developed by Valery Asiryan, Yerevan, Armenia (2025).
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FastRealWeylHeisenbergTransform : RealWeylHeisenbergTransform, IWindowTransform, ITransform
     {

--- a/sources/Window/FastShortTimeFourierTransform.cs
+++ b/sources/Window/FastShortTimeFourierTransform.cs
@@ -7,11 +7,11 @@ namespace UMapx.Window
 {
     /// <summary>
     /// Defines fast short-time Fourier transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Short-time_Fourier_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class FastShortTimeFourierTransform : IWindowTransform, ITransform
     {

--- a/sources/Window/FastWeylHeisenbergTransform.Asiryan.cs
+++ b/sources/Window/FastWeylHeisenbergTransform.Asiryan.cs
@@ -6,11 +6,11 @@ namespace UMapx.Window
 {
     /// <summary>
     /// Defines fast Weyl-Heisenberg transform.
+    /// </summary>
     /// <remarks>
     /// The class represents a computationally efficient implementation of one-dimensional and two-dimensional discrete orthogonal
     /// Weyl-Heisenberg transforms. This implementation was designed and developed by Valery Asiryan, Yerevan, Armenia (2025).
     /// </remarks>
-    /// </summary>
     public partial class FastWeylHeisenbergTransform
     {
         #region Internal methods and classes
@@ -334,11 +334,11 @@ namespace UMapx.Window
         /// t<sub>n0</sub>[r] = g[r*M + (n0 + M/2) mod M], dimensions [M, L]</description></item>
         /// </list>
         /// </para>
+        /// </summary>
         /// <remarks>
         /// The cache is specific to a given combination of (N, M, window function).
         /// If the window changes, the cache must be rebuilt.
         /// </remarks>
-        /// </summary>
         internal sealed class PolyphaseCache
         {
             /// <summary>

--- a/sources/Window/FastWeylHeisenbergTransform.cs
+++ b/sources/Window/FastWeylHeisenbergTransform.cs
@@ -7,11 +7,11 @@ namespace UMapx.Window
 {
     /// <summary>
     /// Defines fast Weyl-Heisenberg transform.
+    /// </summary>
     /// <remarks>
     /// The class represents a computationally efficient implementation of one-dimensional and two-dimensional discrete orthogonal
     /// Weyl-Heisenberg transforms. This implementation was designed and developed by Valery Asiryan, Yerevan, Armenia (2025).
     /// </remarks>
-    /// </summary>
     [Serializable]
     public partial class FastWeylHeisenbergTransform : WeylHeisenbergTransform, IWindowTransform, ITransform
     {

--- a/sources/Window/FastZakTransform.cs
+++ b/sources/Window/FastZakTransform.cs
@@ -26,10 +26,10 @@ namespace UMapx.Window
         }
         /// <summary>
         /// Gets or sets number of frequency shifts [4, N/2].
+        /// </summary>
         /// <remarks>
         /// Even number.
         /// </remarks>
-        /// </summary>
         public int M
         {
             get

--- a/sources/Window/RealWeylHeisenbergTransform.cs
+++ b/sources/Window/RealWeylHeisenbergTransform.cs
@@ -7,11 +7,11 @@ namespace UMapx.Window
 {
     /// <summary>
     /// Defines a group of real orthogonal bases and discrete Weyl-Heisenberg transforms.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://ieeexplore.ieee.org/document/8711969/
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class RealWeylHeisenbergTransform : WeylHeisenbergTransform, IWindowTransform, ITransform
     {
@@ -28,10 +28,10 @@ namespace UMapx.Window
         #region Weyl-Heisenberg static components
         /// <summary>
         /// Returns the real Weyl-Heisenberg basis matrix.
+        /// </summary>
         /// <remarks>
         /// Matrix dimension [2N, 2N], where N = M * L.
         /// </remarks>
-        /// </summary>
         /// <param name="g0">Function</param>
         /// <param name="M">Number of frequency shifts [4, N/4]</param>
         /// <returns>Matrix</returns>
@@ -78,10 +78,10 @@ namespace UMapx.Window
         }
         /// <summary>
         /// Returns the real Weyl-Heisenberg basis matrix.
+        /// </summary>
         /// <remarks>
         /// Matrix dimension [2N, 2N], where N = M * L.
         /// </remarks>
-        /// </summary>
         /// <param name="window">Windows function</param>
         /// <param name="N">Number of samples</param>
         /// <param name="M">Number of frequency shifts [4, N/4]</param>
@@ -93,10 +93,10 @@ namespace UMapx.Window
         }
         /// <summary>
         /// Returns the real Weyl-Heisenberg basis matrix.
+        /// </summary>
         /// <remarks>
         /// Matrix dimension [2N, 2N], where N = M * L.
         /// </remarks>
-        /// </summary>
         /// <param name="g0">Function</param>
         /// <param name="M">Number of frequency shifts [4, N/4]</param>
         /// <param name="orthogonalize">Orthogonalized matrix or not</param>

--- a/sources/Window/ShortTimeFourierTransform.cs
+++ b/sources/Window/ShortTimeFourierTransform.cs
@@ -7,11 +7,11 @@ namespace UMapx.Window
 {
     /// <summary>
     /// Defines short-time Fourier transform.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Short-time_Fourier_transform
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class ShortTimeFourierTransform : IWindowTransform, ITransform
     {

--- a/sources/Window/WeylHeisenbergTransform.cs
+++ b/sources/Window/WeylHeisenbergTransform.cs
@@ -7,11 +7,11 @@ namespace UMapx.Window
 {
     /// <summary>
     /// Defines a group of orthogonal bases and discrete Weyl-Heisenberg transforms.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://ieeexplore.ieee.org/document/8711969/
     /// </remarks>
-    /// </summary>
     [Serializable]
     public class WeylHeisenbergTransform : IWindowTransform, ITransform
     {
@@ -85,10 +85,10 @@ namespace UMapx.Window
         #region Weyl-Heisenberg static components
         /// <summary>
         /// Returns the complex Weyl-Heisenberg basis matrix.
+        /// </summary>
         /// <remarks>
         /// Matrix dimension [N, 2N], where N = M * L.
         /// </remarks>
-        /// </summary>
         /// <param name="g0">Function</param>
         /// <param name="M">Number of frequency shifts</param>
         /// <returns>Matrix</returns>
@@ -132,10 +132,10 @@ namespace UMapx.Window
         }
         /// <summary>
         /// Returns the complex Weyl-Heisenberg basis matrix.
+        /// </summary>
         /// <remarks>
         /// Matrix dimension [N, 2N], where N = M * L.
         /// </remarks>
-        /// </summary>
         /// <param name="window">Windows function</param>
         /// <param name="N">Number of samples</param>
         /// <param name="M">Number of frequency shifts [4, N/2]</param>
@@ -147,10 +147,10 @@ namespace UMapx.Window
         }
         /// <summary>
         /// Returns the complex Weyl-Heisenberg basis matrix.
+        /// </summary>
         /// <remarks>
         /// Matrix dimension [N, 2N], where N = M * L.
         /// </remarks>
-        /// </summary>
         /// <param name="g0">Function</param>
         /// <param name="M">Number of frequency shifts [4, N/2]</param>
         /// <param name="orthogonalize">Orthogonalized matrix or not</param>

--- a/sources/Window/WindowBase.cs
+++ b/sources/Window/WindowBase.cs
@@ -4,11 +4,11 @@ namespace UMapx.Window
 {
     /// <summary>
     /// Defines the class for window functions.
+    /// </summary>
     /// <remarks>
     /// More information can be found on the website:
     /// https://en.wikipedia.org/wiki/Window_function
     /// </remarks>
-    /// </summary>
     public abstract class WindowBase : IWindow
     {
         #region Private data

--- a/sources/Window/ZakTransform.cs
+++ b/sources/Window/ZakTransform.cs
@@ -26,10 +26,10 @@ namespace UMapx.Window
         }
         /// <summary>
         /// Gets or sets number of frequency shifts [4, N/2].
+        /// </summary>
         /// <remarks>
         /// Even number.
         /// </remarks>
-        /// </summary>
         public int M
         {
             get


### PR DESCRIPTION
## Summary
- separate `<remarks>` blocks from `<summary>` across the codebase
- ensure XML documentation follows `summary` then `remarks`

## Testing
- `dotnet build UMapx.sln` *(fails: command not found)*
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ba39c49d748321aba4b8d96e548513