### PR TITLE
docs: clarify sRGB parameter

### DIFF
--- a/sources/Colorspace/RGB.cs
+++ b/sources/Colorspace/RGB.cs
@@ -350,7 +350,7 @@ namespace UMapx.Colorspace
         /// <summary>
         /// Calculates the brightness value in the standard (PAL/NTSC).
         /// </summary>
-        /// <param name="rgb">RGB structure</param>
+        /// <param name="rgb">sRGB structure</param>
         /// <returns>Value</returns>
         public static float PAL(sRGB rgb)
         {


### PR DESCRIPTION
## Summary
- fix XML comment for PAL(sRGB) overload to reference `sRGB` structure
- review other overloads for consistent documentation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: Ign:1 https://mise.jdx.dev/deb stable InRelease; waiting for headers, aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3c4011c483218bd1ac3fa348c791