### PR TITLE
Fix Cyrillic C in CMYK XML comment

### DIFF
--- a/sources/Colorspace/CMYK.cs
+++ b/sources/Colorspace/CMYK.cs
@@ -4,7 +4,7 @@ using UMapx.Core;
 namespace UMapx.Colorspace
 {
     /// <summary>
-    /// Defines a color model СMYK.
+    /// Defines a color model CMYK.
     /// </summary>
     [Serializable]
     public struct CMYK : IColorSpace, ICloneable


### PR DESCRIPTION
## Summary
- replace Cyrillic C with Latin C in CMYK comment

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*
- `dotnet build UMapx.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68badd40efe08321a1d07b9c4768a4c0