### PR TITLE
Fix PointInt equality comments

### DIFF
--- a/sources/Core/PointInt.cs
+++ b/sources/Core/PointInt.cs
@@ -84,7 +84,7 @@ namespace UMapx.Core
 
         #region Bools
         /// <summary>
-        /// Checks if two PointDouble objects are equal.
+        /// Checks if two PointInt objects are equal.
         /// </summary>
         /// <param name="a">Pair of numbers</param>
         /// <param name="b">Pair of numbers</param>
@@ -94,7 +94,7 @@ namespace UMapx.Core
             return (a.X == b.X && a.Y == b.Y);
         }
         /// <summary>
-        /// Checks if two PointDouble objects are not equal.
+        /// Checks if two PointInt objects are not equal.
         /// </summary>
         /// <param name="a">Pair of numbers</param>
         /// <param name="b">Pair of numbers</param>


### PR DESCRIPTION
## Summary
- fix equality operator comments in PointInt

## Testing
- `dotnet test sources/UMapx.sln -v normal`

------
https://chatgpt.com/codex/tasks/task_e_68baf39e63248321b5080194dd237a48