### PR TITLE
Fix AHSL hue comment to match implementation

### DIFF
--- a/sources/Colorspace/AHSL.cs
+++ b/sources/Colorspace/AHSL.cs
@@ -19,7 +19,7 @@ namespace UMapx.Colorspace
         /// <summary>
         /// Creates an instance of the AHSL structure.
         /// </summary>
-        /// <param name="h">Hue [0, 360]</param>
+        /// <param name="h">Hue [0, 359]</param>
         /// <param name="s">Saturation [0, 255]</param>
         /// <param name="l">Lightness [-100, 100]</param>
         public AHSL(float h, float s, float l)


### PR DESCRIPTION
## Summary
- correct AHSL constructor hue parameter comment to `[0, 359]`

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bafa9472788321a3a977cf9f6196e7