### PR TITLE
Fix #endregion directives in distribution classes

### DIFF
--- a/sources/Distribution/Gaussian.cs
+++ b/sources/Distribution/Gaussian.cs
@@ -16,7 +16,7 @@ namespace UMapx.Distribution
         #region Private data
         private float sigma = 1;
         private float mu = 0;
-        #endregion;
+        #endregion
 
         #region Gaussian components
         /// <summary>

--- a/sources/Distribution/LogGaussian.cs
+++ b/sources/Distribution/LogGaussian.cs
@@ -16,7 +16,7 @@ namespace UMapx.Distribution
         #region Private data
         private float sigma = 1;
         private float mu = 0;
-        #endregion;
+        #endregion
 
         #region GaussianLog components
         /// <summary>

--- a/sources/Distribution/Rayleigh.cs
+++ b/sources/Distribution/Rayleigh.cs
@@ -15,7 +15,7 @@ namespace UMapx.Distribution
     {
         #region Private data
         private float sigma = 1;
-        #endregion;
+        #endregion
 
         #region Rayleigh components
         /// <summary>


### PR DESCRIPTION
## Summary
- remove stray semicolons after `#endregion` in Gaussian, LogGaussian, and Rayleigh distributions

## Testing
- `dotnet build sources/UMapx.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bafa530e4883218b6f6f2d6ee8c996