### PR TITLE
docs: fix Compar return documentation

### DIFF
--- a/sources/Core/StringOptions.cs
+++ b/sources/Core/StringOptions.cs
@@ -109,7 +109,7 @@ namespace UMapx.Core
         /// Example: "1 + 2i", "0.321 + 11i", ".1i".
         /// </remarks>
         /// <param name="s">Input string</param>
-        /// <returns>Text as a sequence of Unicode characters</returns>
+        /// <returns>Complex32 value</returns>
         public static Complex32 Compar(string s)
         {
             string u = s.Replace(" ", "");


### PR DESCRIPTION
## Summary
- clarify the return type of `StringOptions.Compar`

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68bafd5704148321adf56b10936c01c7