### PR TITLE
Fix typo in Cauchy components region

### DIFF
--- a/sources/Distribution/Cauchy.cs
+++ b/sources/Distribution/Cauchy.cs
@@ -18,7 +18,7 @@ namespace UMapx.Distribution
         private float x0 = 0;
         #endregion
 
-        #region Caushi components
+        #region Cauchy components
         /// <summary>
         /// Initializes the Cauchy distribution.
         /// </summary>
@@ -154,6 +154,6 @@ namespace UMapx.Distribution
                 return Maths.Log(4 * Maths.Pi * g);
             }
         }
-        #endregion
+        #endregion Cauchy components
     }
 }


### PR DESCRIPTION
## Summary
- fix typo in Cauchy region component name

## Testing
- `dotnet test sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68baffa2f8688321864ccd467fb33a3d