### PR TITLE
docs: clarify FIR filter remark

### DIFF
--- a/sources/Response/FIR.cs
+++ b/sources/Response/FIR.cs
@@ -7,9 +7,9 @@ namespace UMapx.Response
     /// Defines a filter with a finite impulse response.
     /// </summary>
     /// <remarks>
-    /// A filter with a finite impulse response (transverse filter, FIR filter or FIR filter) is one of the types of linear
-    /// digital filters, a characteristic feature of which is the limited time of its impulse response
-    /// (from some point in time it becomes exactly equal to zero). Such a filter is also called non-recursive due to the lack of feedback.
+    /// A filter with a finite impulse response, also called a transversal (FIR) filter, is one type of linear
+    /// digital filter whose impulse response becomes exactly zero after a finite time.
+    /// Such a filter is also called non-recursive due to the lack of feedback.
     /// The denominator of the transfer function of such a filter is a certain constant.
     /// </remarks>
     [Serializable]


### PR DESCRIPTION
## Summary
- clarify FIR remarks by replacing redundant phrase with concise wording

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bb02d8d6248321bd7e208446fdcd7f