### PR TITLE
Handle zero divisor in Gcd

### DIFF
--- a/sources/Core/Maths.cs
+++ b/sources/Core/Maths.cs
@@ -1438,6 +1438,8 @@ namespace UMapx.Core
         /// <returns>Integer number</returns>
         public static int Gcd(int a, int b)
         {
+            if (b == 0) return Math.Abs(a);
+
             int q = Maths.Mod(a, b);
             while (q != 0)
             {
@@ -1455,6 +1457,8 @@ namespace UMapx.Core
         /// <returns>Integer number</returns>
         public static long Gcd(long a, long b)
         {
+            if (b == 0) return Math.Abs(a);
+
             long q = Maths.Mod(a, b);
             while (q != 0)
             {


### PR DESCRIPTION
## Summary
- Prevent modulo by zero in Gcd methods by returning `Math.Abs(a)` when `b` is zero
- Execute Euclidean algorithm only when the divisor is non-zero

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bc35c2cf1883219638172c16ec1b33