### PR TITLE
Fix tricube kernel to use absolute value

### DIFF
--- a/sources/Core/Kernel.cs
+++ b/sources/Core/Kernel.cs
@@ -213,7 +213,7 @@ namespace UMapx.Core
             {
                 return 0;
             }
-            return 0.864197531f * (float)Math.Pow((1 - x * x * x), 3);
+            return 0.864197531f * (float)Math.Pow((1 - abs * abs * abs), 3);
         }
         #endregion
 


### PR DESCRIPTION
## Summary
- ensure tricube kernel uses `|x|^3` for symmetry

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-6.0` *(fails: Package 'dotnet-sdk-6.0' has no installation candidate)*


------
https://chatgpt.com/codex/tasks/task_e_68bc3d0b92d883219351856aa6ce34f2