### PR TITLE
Fix Poisson lambda validation

### DIFF
--- a/sources/Distribution/Poisson.cs
+++ b/sources/Distribution/Poisson.cs
@@ -41,8 +41,8 @@ namespace UMapx.Distribution
             }
             set
             {
-                if (value < 0)
-                    throw new ArgumentException("Invalid argument value");
+                if (value <= 0)
+                    throw new ArgumentException("Lambda must be positive");
 
                 this.l = value;
             }


### PR DESCRIPTION
## Summary
- enforce positive lambda for Poisson distribution
- clarify error message when lambda is non-positive

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bcac37c30883219587672b8a12da1d