### PR TITLE
Enforce positive K parameter values

### DIFF
--- a/sources/Distribution/ChiSquare.cs
+++ b/sources/Distribution/ChiSquare.cs
@@ -37,7 +37,7 @@ namespace UMapx.Distribution
             }
             set
             {
-                if (value < 0)
+                if (value <= 0)
                     throw new ArgumentException("Invalid argument value");
 
                 this.k = value;

--- a/sources/Distribution/Gamma.cs
+++ b/sources/Distribution/Gamma.cs
@@ -60,7 +60,7 @@ namespace UMapx.Distribution
             }
             set
             {
-                if (value < 0)
+                if (value <= 0)
                     throw new ArgumentException("Invalid argument value");
 
                 this.k = value;

--- a/sources/Distribution/Pareto.cs
+++ b/sources/Distribution/Pareto.cs
@@ -60,7 +60,7 @@ namespace UMapx.Distribution
             }
             set
             {
-                if (value < 0)
+                if (value <= 0)
                     throw new ArgumentException("Invalid argument value");
 
                 this.k = value;


### PR DESCRIPTION
## Summary
- ensure ChiSquare.K rejects non-positive degrees of freedom
- ensure Gamma.K requires positive parameter value
- tighten Pareto.K validation to demand positive scale factor

## Testing
- `dotnet build sources/UMapx.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcac1100808321a8723f37bf48da05