### PR TITLE
docs: clarify heap peek and extract return values

### DIFF
--- a/sources/Core/HeapT.cs
+++ b/sources/Core/HeapT.cs
@@ -48,9 +48,9 @@ namespace UMapx.Core
         }
 
         /// <summary>
-        /// Gets a heap peek.
+        /// Returns the element at the top of the heap without removing it.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Element at the top of the heap.</returns>
         public T Peek()
         {
             if (Count == 0)
@@ -61,7 +61,7 @@ namespace UMapx.Core
         /// <summary>
         /// Extracts an item from the heap.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The removed root element.</returns>
         public T Extract()
         {
             if (Count == 0)


### PR DESCRIPTION
## Summary
- clarify that `Peek` returns the heap root without removing
- document `Extract` return value

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bcb55cc3f0832183a1a4562f6102f5