### PR TITLE
Use float-based square roots in FastCosineTransform

### DIFF
--- a/sources/Transform/FastCosineTransform.cs
+++ b/sources/Transform/FastCosineTransform.cs
@@ -73,11 +73,11 @@ namespace UMapx.Transform
 
             float[] C = new float[N];
 
-            Complex32 c = -Maths.I * Maths.Pi / ( 2 * N );
+            Complex32 c = -Maths.I * Maths.Pi / (2f * N);
 
             for (k = 0; k < N; k++)
             {
-                C[k] = 2.0f * (B[k] * Maths.Exp(c * k)).Real / Maths.Sqrt( 2 * N );
+                C[k] = 2.0f * (B[k] * Maths.Exp(c * k)).Real / Maths.Sqrt(2f * N);
             }
 
             C[0] = C[0] / Maths.Sqrt2; // DCT-I
@@ -93,14 +93,14 @@ namespace UMapx.Transform
         {
             int N = B.Length, N2 = N / 2, i, k;
             Complex32[] A = new Complex32[N];
-            Complex32 c = Maths.I * Maths.Pi / ( 2 * N );
+            Complex32 c = Maths.I * Maths.Pi / (2f * N);
 
             for (k = 0; k < N; k++)
             {
-                A[k] = B[k] * Maths.Exp(c * k) * Math.Sqrt(2 * N);
+                A[k] = B[k] * Maths.Exp(c * k) * Maths.Sqrt(2f * N);
             }
 
-            A[0] /= Math.Sqrt(2); // DCT-I
+            A[0] /= Maths.Sqrt(2f); // DCT-I
 
             A = FFT.Backward(A);
 


### PR DESCRIPTION
## Summary
- ensure cosine transform uses float-based square roots and arithmetic

## Testing
- `dotnet test sources/UMapx.sln`
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68be0130a1848321ae40e58b44251c91