### PR TITLE
Ensure float exponent in Complex32 differentiation

### DIFF
--- a/sources/Analysis/Differentiation.cs
+++ b/sources/Analysis/Differentiation.cs
@@ -161,7 +161,7 @@ namespace UMapx.Analysis
             }
 
             // result
-            return sum / Math.Pow(h, order);
+            return sum / Maths.Pow(h, order);
         }
         #endregion
 


### PR DESCRIPTION
## Summary
- use `Maths.Pow` so complex differentiation divides by a `float`

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68be014fa7ac8321a46fc392c5829ecb