### PR TITLE
Fix Rayleigh excess kurtosis formula

### DIFF
--- a/sources/Distribution/Rayleigh.cs
+++ b/sources/Distribution/Rayleigh.cs
@@ -116,7 +116,7 @@ namespace UMapx.Distribution
         {
             get
             {
-                return -(6 * Maths.Pi - 24 * Maths.Pi + 16) / Maths.Pow(4 - Maths.Pi);
+                return (-6 * Maths.Pi * Maths.Pi + 24 * Maths.Pi - 16) / Maths.Pow(4 - Maths.Pi);
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- Correct Rayleigh distribution excess kurtosis formula to `(-6π² + 24π - 16) / (4 - π)²`

## Testing
- `dotnet build sources/UMapx.sln` *(fails: Unable to resolve 'NETStandard.Library (>= 2.0.3)' for '.NETStandard,Version=v2.0')*

------
https://chatgpt.com/codex/tasks/task_e_68be09c902508321936f0ee56421438e