### PR TITLE
Fix arcsine density for out-of-support values

### DIFF
--- a/sources/Distribution/Arcsine.cs
+++ b/sources/Distribution/Arcsine.cs
@@ -91,12 +91,12 @@ namespace UMapx.Distribution
         public float Function(float x)
         {
             if (x > 1)
-                return 1.0f;
+                return 0.0f;
 
             if (x < 0)
                 return 0.0f;
 
-            return 1.0f / (float)(Math.PI * Math.Sqrt(x * (1 - x)));
+            return 1.0f / (Maths.Pi * Maths.Sqrt(x * (1 - x)));
         }
         #endregion
     }


### PR DESCRIPTION
## Summary
- Correct arcsine distribution's probability density to return 0 outside [0,1]
- Use `Maths` constants and methods for the density formula

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package dotnet-sdk-7.0)*

------
https://chatgpt.com/codex/tasks/task_e_68be0a9ce4388321bef88ed3706f2484