### PR TITLE
Fix Bernoulli excess kurtosis formula

### DIFF
--- a/sources/Distribution/Bernoulli.cs
+++ b/sources/Distribution/Bernoulli.cs
@@ -132,7 +132,7 @@ namespace UMapx.Distribution
         {
             get
             {
-                return (6 * p * p - 6 * p + 1) / p * (1 - p);
+                return (6 * p * p - 6 * p + 1) / (p * (1 - p));
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- Correct Bernoulli distribution's excess kurtosis calculation by grouping denominator as `p * (1 - p)`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0aa28838832188c764fa7e8c2813