### PR TITLE
Use stable log in Student density

### DIFF
--- a/sources/Distribution/Student.cs
+++ b/sources/Distribution/Student.cs
@@ -169,7 +169,7 @@ namespace UMapx.Distribution
         /// <returns>Logarithm of the density</returns>
         private float LogFunction(float x)
         {
-            return lambda - ((degrees + 1) / 2.0f) * Maths.Log((x * x) / degrees);
+            return lambda - ((degrees + 1) / 2.0f) * Maths.Log(1 + (x * x) / degrees);
         }
         #endregion
     }


### PR DESCRIPTION
## Summary
- ensure Student log-density uses `Maths.Log(1 + (x * x) / degrees)` for numerical stability
- confirm density function uses the adjusted log form

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68be0aa4da948321aa8b4dbda95b6e64