### PR TITLE
Fix geometric distribution CDF

### DIFF
--- a/sources/Distribution/Geometric.cs
+++ b/sources/Distribution/Geometric.cs
@@ -132,7 +132,7 @@ namespace UMapx.Distribution
         /// <summary>
         /// Returns the value of the probability distribution function.
         /// </summary>
-        /// <param name="x">Value</param>
+        /// <param name="x">Number of failures before the first success</param>
         /// <returns>Value</returns>
         public float Distribution(float x)
         {
@@ -140,7 +140,8 @@ namespace UMapx.Distribution
             {
                 return 0;
             }
-            return 1 - Maths.Pow(q, x);
+            x = Maths.Floor(x); // x is interpreted as the number of failures before first success
+            return 1 - Maths.Pow(q, x + 1);
         }
         /// <summary>
         /// Returns the value of differential entropy.


### PR DESCRIPTION
## Summary
- Correct geometric distribution CDF to use 1 - q^(x + 1)
- Document that input represents failures before first success and floor the exponent

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68be0a9587908321bc14f053a60eb2ec