### PR TITLE
Fix Logarithmic distribution support and CDF

### DIFF
--- a/sources/Distribution/Logarithmic.cs
+++ b/sources/Distribution/Logarithmic.cs
@@ -106,36 +106,46 @@ namespace UMapx.Distribution
         /// <summary>
         /// Returns the value of the probability distribution function.
         /// </summary>
-        /// <param name="x">Value</param>
+        /// <param name="x">Value (x ≥ 1)</param>
         /// <returns>Value</returns>
         public float Distribution(float x)
         {
-            if (x <= 0)
+            if (x < 1)
             {
                 return 0;
             }
-            if (x > 1)
+
+            int n = (int)Maths.Floor(x);
+            float c = -1 / Maths.Log(1 - p);
+            float sum = 0;
+
+            for (int k = 1; k <= n; k++)
             {
-                return 0;
+                sum += c * Maths.Pow(p, k) / k;
             }
-            return 1 + Special.Beta(x + 1, 0) / Maths.Log(1 - p);
+
+            return sum;
         }
         /// <summary>
-        /// Returns the value of the probability density function.
+        /// Returns the value of the probability mass function.
         /// </summary>
-        /// <param name="x">Value</param>
+        /// <param name="x">Value (integer x ≥ 1)</param>
         /// <returns>Value</returns>
         public float Function(float x)
         {
-            if (x <= 0)
+            if (x < 1)
             {
                 return 0;
             }
-            if (x > 1)
+
+            int k = (int)Maths.Floor(x);
+
+            if (x != k)
             {
                 return 0;
             }
-            return -1 / Maths.Log(1 - p) * Maths.Pow(p, x) / x;
+
+            return -1 / Maths.Log(1 - p) * Maths.Pow(p, k) / k;
         }
         /// <summary>
         /// Gets the value of entropy.


### PR DESCRIPTION
## Summary
- enforce integer-only PMF for Logarithmic distribution
- compute CDF by summing PMF for integer domain and drop unused Special.Beta call
- update method comments to state x ≥ 1

## Testing
- `dotnet build sources/UMapx.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68be0aa0a8a88321a5630e6bab4d3d07