### PR TITLE
Handle undefined Pareto mean

### DIFF
--- a/sources/Distribution/Pareto.cs
+++ b/sources/Distribution/Pareto.cs
@@ -83,7 +83,11 @@ namespace UMapx.Distribution
         {
             get
             {
-                return (k * xm) / (k - 1);
+                if (k > 1)
+                {
+                    return (k * xm) / (k - 1);
+                }
+                return float.PositiveInfinity;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- Return positive infinity for Pareto mean when shape parameter \(k\) \le 1

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68be0c95f8c48321a94c320a6246167e