### PR TITLE
Handle mode of Weibull distribution for k ≤ 1

### DIFF
--- a/sources/Distribution/Weibull.cs
+++ b/sources/Distribution/Weibull.cs
@@ -100,7 +100,7 @@ namespace UMapx.Distribution
         {
             get
             {
-                return l * Maths.Pow(k - 1, 1.0f / k) / Maths.Pow(k, 1.0f / k);
+                return k > 1 ? l * Maths.Pow((k - 1f) / k, 1f / k) : 0f;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- prevent invalid computation of Weibull distribution mode when shape ≤ 1

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0c9b89d08321b1c4f8e729246d70