### PR TITLE
Reject zero for Gamma.Thetta

### DIFF
--- a/sources/Distribution/Gamma.cs
+++ b/sources/Distribution/Gamma.cs
@@ -43,7 +43,7 @@ namespace UMapx.Distribution
             }
             set
             {
-                if (value < 0)
+                if (value <= 0)
                     throw new ArgumentException("Invalid argument value");
 
                 this.thetta = value;


### PR DESCRIPTION
## Summary
- enforce positive-only checks for Gamma distribution theta parameter

## Testing
- `dotnet build sources/UMapx.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f67bad4832195c8bbe38ff281e0