### PR TITLE
Handle undefined Student mean

### DIFF
--- a/sources/Distribution/Student.cs
+++ b/sources/Distribution/Student.cs
@@ -60,9 +60,12 @@ namespace UMapx.Distribution
         /// <summary>
         /// Gets the mean value.
         /// </summary>
+        /// <remarks>
+        /// For degrees of freedom ≤ 1, the mean is undefined and returns <see cref="float.NaN"/>.
+        /// </remarks>
         public float Mean
         {
-            get { return 0; }
+            get => degrees > 1 ? 0f : float.NaN;
         }
         /// <summary>
         /// Gets the median value.


### PR DESCRIPTION
## Summary
- Handle undefined Student t-distribution mean by returning NaN when degrees of freedom ≤ 1
- Document that the mean is undefined for degrees of freedom ≤ 1

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0f6561a083218a57807fb772527e