### PR TITLE
Handle small λ in Poisson median

### DIFF
--- a/sources/Distribution/Poisson.cs
+++ b/sources/Distribution/Poisson.cs
@@ -90,12 +90,12 @@ namespace UMapx.Distribution
         /// <summary>
         /// Gets the median value.
         /// </summary>
+        /// <remarks>
+        /// Uses an approximation valid for λ ≥ 1.
+        /// </remarks>
         public float Median
         {
-            get
-            {
-                return Maths.Floor(l + 0.333f - 0.02f / l);
-            }
+            get => l < 1f ? 0f : Maths.Floor(l + 1f / 3f - 0.02f / l);
         }
         /// <summary>
         /// Gets the value of the asymmetry coefficient.


### PR DESCRIPTION
## Summary
- handle small lambda in Poisson median calculation
- document approximation domain for the median

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68be0f5f98b483218fef98631d2aadf6