### PR TITLE
Use non-negative approximation for Chi-square median

### DIFF
--- a/sources/Distribution/ChiSquare.cs
+++ b/sources/Distribution/ChiSquare.cs
@@ -64,13 +64,14 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the median value.
+        /// Gets the median value (approximation).
         /// </summary>
         public float Median
         {
             get
             {
-                return k - 2.0f / 3;
+                // Wilson–Hilferty approximation to keep median non-negative
+                return k * Maths.Pow(1 - 2f / (9f * k), 3f);
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure Chi-square median stays non-negative via Wilson–Hilferty approximation
- document that the median is an approximation

## Testing
- `dotnet test sources/UMapx.sln -v n` *(no tests found)*
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68be0f5c5cd88321ab1549ca597e4f76