### PR TITLE
Ensure Pareto Xm is positive

### DIFF
--- a/sources/Distribution/Pareto.cs
+++ b/sources/Distribution/Pareto.cs
@@ -43,7 +43,7 @@ namespace UMapx.Distribution
             }
             set
             {
-                if (value < 0)
+                if (value <= 0)
                     throw new ArgumentException("Invalid argument value");
 
                 this.xm = value;


### PR DESCRIPTION
## Summary
- guard `Pareto.Xm` property against non-positive values

## Testing
- `dotnet test sources/UMapx.sln`
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68be0f68bca88321ba867ed081b9ce6e