### PR TITLE
docs: fix Beta function summaries

### DIFF
--- a/sources/Core/Special.cs
+++ b/sources/Core/Special.cs
@@ -2902,7 +2902,7 @@ namespace UMapx.Core
 
         #region Beta functions
         /// <summary>
-        /// Returns the value of the beta function: B(a, b) = Г(a) * Г(b) / Г(ab).
+        /// Returns the value of the beta function: B(a, b) = Г(a) * Г(b) / Г(a + b).
         /// </summary>
         /// <param name="a">Value</param>
         /// <param name="b">Value</param>
@@ -2912,7 +2912,7 @@ namespace UMapx.Core
             return Special.Gamma(a) * Special.Gamma(b) / Special.Gamma(a + b);
         }
         /// <summary>
-        /// Returns the value of the beta function: B(a, b) = Г(a) * Г(b) / Г(ab).
+        /// Returns the value of the beta function: B(a, b) = Г(a) * Г(b) / Г(a + b).
         /// </summary>
         /// <param name="a">Value</param>
         /// <param name="b">Value</param>


### PR DESCRIPTION
## Summary
- correct Beta function summaries to use Γ(a + b)

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68be13addf288321899800b512a9ebdd