### PR TITLE
Fix Weibull excess to return kurtosis minus 3

### DIFF
--- a/sources/Distribution/Weibull.cs
+++ b/sources/Distribution/Weibull.cs
@@ -125,13 +125,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess coefficient (kurtosis minus 3).
         /// </summary>
         public float Excess
         {
             get
             {
-                return (Special.Gamma(1.0f + 4.0f / k) * Maths.Pow(l, 4) - 4 * Mean * Special.Gamma(1 + 3.0f / k) * Maths.Pow(l, 3) + 6 * Maths.Pow(Mean, 2) * Maths.Pow(l, 2) * Special.Gamma(1.0f + 2.0f / k) - 3 * Maths.Pow(Mean, 4)) / (Variance * Variance);
+                return (Special.Gamma(1.0f + 4.0f / k) * Maths.Pow(l, 4) - 4 * Mean * Special.Gamma(1 + 3.0f / k) * Maths.Pow(l, 3) + 6 * Maths.Pow(Mean, 2) * Maths.Pow(l, 2) * Special.Gamma(1.0f + 2.0f / k) - 3 * Maths.Pow(Mean, 4)) / (Variance * Variance) - 3f;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- correct Weibull distribution `Excess` property to return kurtosis minus 3
- clarify XML documentation to refer to excess (kurtosis minus 3)

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68be1635948c8321bc72d16dc3238f8f