### PR TITLE
Add adjustable normalized Morlet wavelet

### DIFF
--- a/sources/Wavelet/MorletWavelet.cs
+++ b/sources/Wavelet/MorletWavelet.cs
@@ -4,17 +4,35 @@ using UMapx.Core;
 namespace UMapx.Wavelet
 {
     /// <summary>
-    /// Defines the continuous Morlet wavelet.
+    /// Defines the normalized continuous Morlet wavelet with zero mean.
     /// </summary>
     [Serializable]
     public class MorletWavelet : IFloatWavelet
     {
+        #region Private data
+        private float omega0 = 5;
+        #endregion
+
         #region Wavelet components
         /// <summary>
         /// Initializes the continuous Morlet wavelet.
         /// </summary>
         public MorletWavelet()
         {
+        }
+        /// <summary>
+        /// Gets or sets the central frequency.
+        /// </summary>
+        public float Omega0
+        {
+            get
+            {
+                return this.omega0;
+            }
+            set
+            {
+                this.omega0 = value;
+            }
         }
         /// <summary>
         /// Returns the value of the scaling function.
@@ -26,14 +44,14 @@ namespace UMapx.Wavelet
             throw new NotSupportedException();
         }
         /// <summary>
-        /// Returns the value of the wavelet function.
+        /// Returns the value of the normalized wavelet function with zero mean.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Function</returns>
         public float Wavelet(float x)
         {
             float x2 = x * x;
-            return Maths.Exp(-x2 / 2) * Maths.Cos(5 * x);
+            return Maths.Exp(-x2 / 2) * (Maths.Cos(omega0 * x) - Maths.Exp(-0.5f * omega0 * omega0)) / Maths.Pow(Maths.Pi, 0.25f);
         }
         #endregion
     }


### PR DESCRIPTION
## Summary
- allow Morlet wavelet central frequency adjustment through `Omega0`
- normalize Morlet wavelet to have zero mean

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68be1bc90e78832180eb08d6274e8898