### PR TITLE
Fix Bernoulli excess kurtosis calculation

### DIFF
--- a/sources/Distribution/Bernoulli.cs
+++ b/sources/Distribution/Bernoulli.cs
@@ -126,13 +126,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
         public float Excess
         {
             get
             {
-                return (6 * p * p - 6 * p + 1) / (p * (1 - p));
+                return (6 * p * p - 6 * p + 1) / (p * (1 - p)) - 3f;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- correct Bernoulli distribution's excess kurtosis formula
- clarify XML comment to specify excess kurtosis (kurtosis minus 3)

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68bead73ddc48321b6a8b905ad20e0b3