### PR TITLE
Fix Poisson CDF using GammaP

### DIFF
--- a/sources/Distribution/Poisson.cs
+++ b/sources/Distribution/Poisson.cs
@@ -141,7 +141,8 @@ namespace UMapx.Distribution
             {
                 return 0;
             }
-            return Special.GammaQ(x + 1, l);
+            x = Maths.Floor(x);
+            return Special.GammaP(x + 1, l);
         }
         /// <summary>
         /// Returns the value of differential entropy.


### PR DESCRIPTION
## Summary
- use GammaP for Poisson CDF and floor x to handle discrete support

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68beb439d5388321bc04faf6c8060d01