### PR TITLE
Use regularized incomplete beta for binomial CDF

### DIFF
--- a/sources/Distribution/Binomial.cs
+++ b/sources/Distribution/Binomial.cs
@@ -182,7 +182,7 @@ namespace UMapx.Distribution
 
             float a = n - x;
             float b = x + 1;
-            return Special.BetaIncomplete(a, b, q);
+            return Special.BetaIncompleteRegularized(a, b, q);
         }
         /// <summary>
         /// Returns the value of differential entropy.


### PR DESCRIPTION
## Summary
- use regularized incomplete beta function in binomial CDF implementation
- verify distribution returns correct limits for x < 0 and x >= n

## Testing
- `dotnet build sources/UMapx.sln`
- manual check of boundary cases via console app

------
https://chatgpt.com/codex/tasks/task_e_68beb44495e083219e9a53fee9062593