### PR TITLE
Enforce positive scale in Gumbel distribution

### DIFF
--- a/sources/Distribution/Gumbel.cs
+++ b/sources/Distribution/Gumbel.cs
@@ -53,8 +53,8 @@ namespace UMapx.Distribution
             }
             set
             {
-                if (value < 0)
-                    throw new ArgumentException("Invalid argument value");
+                if (value <= 0)
+                    throw new ArgumentException("Scale factor β must be greater than 0.");
 
                 this.beta = value;
             }


### PR DESCRIPTION
## Summary
- require `Beta` parameter to be strictly positive in Gumbel distribution
- clarify exception message for invalid `Beta`

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68beb65927008321987429666460bbff