### PR TITLE
Validate integer inputs in Poisson PMF

### DIFF
--- a/sources/Distribution/Poisson.cs
+++ b/sources/Distribution/Poisson.cs
@@ -128,7 +128,12 @@ namespace UMapx.Distribution
             {
                 return 0;
             }
-            return Maths.Exp(-l) * Maths.Pow(l, x) / (float)Special.Factorial(x);
+            int k = (int)x;
+            if (x != Maths.Floor(x))
+            {
+                return 0;
+            }
+            return Maths.Exp(-l) * Maths.Pow(l, k) / (float)Special.Factorial(k);
         }
         /// <summary>
         /// Returns the value of the probability distribution function.


### PR DESCRIPTION
## Summary
- Ensure Poisson PMF only evaluates for integer inputs by checking `x` before factorial computation

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68beb6536cf08321a55290249a3cbe2b