### PR TITLE
Clarify hyperbolic secant entropy for σ=1 variant

### DIFF
--- a/sources/Distribution/HyperbolicSecant.cs
+++ b/sources/Distribution/HyperbolicSecant.cs
@@ -70,9 +70,12 @@ namespace UMapx.Distribution
         /// <summary>
         /// Returns the value of differential entropy.
         /// </summary>
+        /// <remarks>
+        /// This value corresponds to the hyperbolic secant distribution with scale σ = 1.
+        /// </remarks>
         public float Entropy
         {
-            get { return (4.0f / Maths.Pi) * Maths.G; }
+            get { return (2f / Maths.Pi) * Maths.G; }
         }
         /// <summary>
         /// Returns the value of the probability distribution function.


### PR DESCRIPTION
## Summary
- fix entropy constant for hyperbolic secant distribution
- note in comments that the formula applies to the σ=1 scale

## Testing
- `dotnet build sources/UMapx.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68beb65088e8832187a4f25625f4a749