### PR TITLE
Fix hypergeometric skewness denominator

### DIFF
--- a/sources/Distribution/Hypergeometric.cs
+++ b/sources/Distribution/Hypergeometric.cs
@@ -142,7 +142,7 @@ namespace UMapx.Distribution
             get
             {
                 float k1 = (n - 2 * d) * Maths.Pow(n - 1, 0.5f) * (n - 2 * k);
-                float k2 = (n * d * (n - d) * Maths.Pow(n - k, 0.5f) * (n - 2));
+                float k2 = Maths.Sqrt(k * d * (n - d) * (n - k)) * (n - 2);
                 return k1 / k2;
             }
         }


### PR DESCRIPTION
## Summary
- fix denominator of hypergeometric distribution skewness to use square root of full product

## Testing
- `dotnet test sources/UMapx.sln`
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68beb6492e008321b239f44ade68bc5c