### PR TITLE
Ensure BetaPrime parameters are strictly positive

### DIFF
--- a/sources/Distribution/BetaPrime.cs
+++ b/sources/Distribution/BetaPrime.cs
@@ -39,7 +39,7 @@ namespace UMapx.Distribution
             }
             set
             {
-                if (value < 0)
+                if (value <= 0)
                     throw new ArgumentException("Invalid argument value");
 
                 this.alpha = value;
@@ -56,7 +56,7 @@ namespace UMapx.Distribution
             }
             set
             {
-                if (value < 0)
+                if (value <= 0)
                     throw new ArgumentException("Invalid argument value");
 
                 this.beta = value;


### PR DESCRIPTION
## Summary
- require positive (non-zero) values for Alpha and Beta in BetaPrime distribution

## Testing
- `dotnet build sources/UMapx.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bec561995c8321a7fb2aaef3f6628f