### PR TITLE
Fix Levy entropy formula

### DIFF
--- a/sources/Distribution/Levy.cs
+++ b/sources/Distribution/Levy.cs
@@ -121,7 +121,7 @@ namespace UMapx.Distribution
         {
             get
             {
-                return 1.0f + Maths.Log(2.0f * Maths.Sqrt(Maths.Pi * scale));
+                return 1.0f + Maths.Log(Maths.Sqrt(2.0f * Maths.Pi * scale));
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- correct Levy entropy formula to use ln(sqrt(2πc))

## Testing
- `dotnet test sources/UMapx.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68bec54cde2c8321abc9aee90a262323