### PR TITLE
Fix normalization constant in ComplexGaussianWavelet

### DIFF
--- a/sources/Wavelet/ComplexGaussianWavelet.cs
+++ b/sources/Wavelet/ComplexGaussianWavelet.cs
@@ -58,7 +58,7 @@ namespace UMapx.Wavelet
             float x2 = x * x;
             Complex32 f0 = Maths.Exp(-x2);
             Complex32 f1 = Maths.Exp(-Maths.I * x);
-            Complex32 f2 = (f1 * f0) / Math.Pow(Math.Exp(-1 / 2) * Math.Pow(2, 0.5) * Math.Pow(Maths.Pi, 0.5), 0.5);
+            Complex32 f2 = (f1 * f0) / Math.Pow(Math.Exp(-0.5) * Math.Pow(2, 0.5) * Math.Pow(Maths.Pi, 0.5), 0.5);
             Complex32 psi = 0;
 
             // Gaussian wavelet ('):


### PR DESCRIPTION
## Summary
- fix floating-point division in ComplexGaussianWavelet normalization constant

## Testing
- `dotnet build sources/UMapx.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bf074b4a2c83218e1d016c2e9e3443