### PR TITLE
Fix circular variance in WrappedCauchy distribution

### DIFF
--- a/sources/Distribution/WrappedCauchy.cs
+++ b/sources/Distribution/WrappedCauchy.cs
@@ -73,7 +73,7 @@ namespace UMapx.Distribution
         /// </summary>
         public float Variance
         {
-            get { return 1 - Maths.Exp(-gamma); }
+            get { return 1 - Maths.Exp(-2 * gamma); } // circular variance
         }
         /// <summary>
         /// Gets the median value.


### PR DESCRIPTION
## Summary
- correct WrappedCauchy variance formula to use `1 - Maths.Exp(-2 * gamma)`
- clarify that the returned value is the circular variance

## Testing
- `dotnet build UMapx.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68bf59134c8c83218102582a94557e57