### PR TITLE
Fix Bartlett-Hann window cosine term sign

### DIFF
--- a/sources/Window/BartlettHann.cs
+++ b/sources/Window/BartlettHann.cs
@@ -27,7 +27,7 @@ namespace UMapx.Window
         public override float Function(float x, int frameSize)
         {
             float a = Math.Abs(Math.Abs(x / (frameSize - 1)) - 0.5f);
-            return 0.62f - 0.48f * a - 0.38f * Cosine.Cosinefunc(2 * x, frameSize);
+            return 0.62f - 0.48f * a + 0.38f * Cosine.Cosinefunc(2 * x, frameSize);
         }
         /// <summary>
         /// Returns the window function.


### PR DESCRIPTION
## Summary
- correct cosine term sign in Bartlett-Hann window to align with standard definition

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c01ee53ce8832187351348d20f3280