### PR TITLE
Fix Parzen window scaling to ensure symmetry

### DIFF
--- a/sources/Window/Parzen.cs
+++ b/sources/Window/Parzen.cs
@@ -34,12 +34,12 @@ namespace UMapx.Window
 
             // props:
             if ((y >= 0) &&
-                (y <= frameSize / 4))
+                (y <= frameSize / 4.0f))
             {
                 return 1.0f - 6.0f * a * a * (1.0f - b);
             }
-            else if (y >= frameSize / 4 &&
-                y <= frameSize / 2)
+            else if (y >= frameSize / 4.0f &&
+                y <= frameSize / 2.0f)
             {
                 return 2 * Maths.Pow(1 - b, 3);
             }


### PR DESCRIPTION
## Summary
- use floating-point division when comparing Parzen window positions for consistent behavior

## Testing
- `dotnet build sources/UMapx.sln`
- `dotnet run --project /tmp/windowtest/windowtest.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c01ee03f408321bfb318ef7814e2bf