### PR TITLE
Handle degenerate Bernoulli entropy

### DIFF
--- a/sources/Distribution/Bernoulli.cs
+++ b/sources/Distribution/Bernoulli.cs
@@ -173,6 +173,10 @@ namespace UMapx.Distribution
         {
             get
             {
+                if (p == 0f || p == 1f)
+                {
+                    return 0f;
+                }
                 return -q * Maths.Log(q) - p * Maths.Log(p);
             }
         }


### PR DESCRIPTION
## Summary
- Avoid log(0) in Bernoulli entropy: return 0 when p is 0 or 1

## Testing
- `dotnet build sources/UMapx.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c02f0a2d888321aefb8bba034ef3fa