### PR TITLE
Ensure integer input for Geometric distribution PDF

### DIFF
--- a/sources/Distribution/Geometric.cs
+++ b/sources/Distribution/Geometric.cs
@@ -125,9 +125,14 @@ namespace UMapx.Distribution
         {
             if (x < 0)
             {
-                return 0;
+                return 0f;
             }
-            return Maths.Pow(q, x) * p;
+            int k = (int)Maths.Floor(x);
+            if (x != k)
+            {
+                return 0f;
+            }
+            return Maths.Pow(q, k) * p;
         }
         /// <summary>
         /// Returns the value of the probability distribution function.


### PR DESCRIPTION
## Summary
- Validate that the geometric distribution PDF only evaluates integer inputs
- Return 0 for negative or fractional values in the PDF

## Testing
- `dotnet build sources/UMapx.sln`
- `dotnet test sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c02f18e3b083219f4c2227dac838ef