### PR TITLE
Fix HyperbolicSecant excess kurtosis value

### DIFF
--- a/sources/Distribution/HyperbolicSecant.cs
+++ b/sources/Distribution/HyperbolicSecant.cs
@@ -54,11 +54,11 @@ namespace UMapx.Distribution
             get { return 0; }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
         public float Excess
         {
-            get { return 2; }
+            get { return -1f; }
         }
         /// <summary>
         /// Gets the support interval of the argument.


### PR DESCRIPTION
## Summary
- correct `HyperbolicSecant.Excess` to return `-1f`
- document that `Excess` represents excess kurtosis (kurtosis minus 3)

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c0b02cf6b08321b078814e1380ed05