### PR TITLE
Handle undefined variance in Cauchy distribution

### DIFF
--- a/sources/Distribution/Cauchy.cs
+++ b/sources/Distribution/Cauchy.cs
@@ -82,14 +82,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the variance value.
+        /// Gets the variance value. Undefined for the Cauchy distribution.
         /// </summary>
         public float Variance
         {
-            get
-            {
-                return float.PositiveInfinity;
-            }
+            get { throw new NotSupportedException(); }
         }
         /// <summary>
         /// Gets the mode value.


### PR DESCRIPTION
## Summary
- Clarify that the Cauchy distribution variance is undefined
- Throw `NotSupportedException` when requesting Cauchy variance

## Testing
- `dotnet test sources/UMapx.csproj`
- `dotnet build sources/UMapx.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c0b9acb4d88321beb43ce401f085cd