### PR TITLE
Fix YCbCr BT.601 coefficients

### DIFF
--- a/sources/Colorspace/YCbCr.cs
+++ b/sources/Colorspace/YCbCr.cs
@@ -162,8 +162,8 @@ namespace UMapx.Colorspace
             float b = blue / 255.0f;
 
             float Y = 0.299f * r + 0.587f * g + 0.114f * b;
-            float Cb = -0.172f * r - 0.339f * g + 0.511f * b + 0.5f;
-            float Cr = 0.511f * r - 0.428f * g - 0.083f * b + 0.5f;
+            float Cb = -0.168736f * r - 0.331264f * g + 0.5f * b + 0.5f;
+            float Cr = 0.5f * r - 0.418688f * g - 0.081312f * b + 0.5f;
 
             return new YCbCr(Y, Cb, Cr);
         }
@@ -187,9 +187,9 @@ namespace UMapx.Colorspace
         {
             get
             {
-                int r = (int)((y + 1.371f * (cr - 0.5f)) * 255);
-                int g = (int)((y - 0.698f * (cr - 0.5f) - 0.336f * (cb - 0.5f)) * 255);
-                int b = (int)((y + 1.732f * (cb - 0.5f)) * 255);
+                int r = (int)((y + 1.402f * (cr - 0.5f)) * 255);
+                int g = (int)((y - 0.344136f * (cb - 0.5f) - 0.714136f * (cr - 0.5f)) * 255);
+                int b = (int)((y + 1.772f * (cb - 0.5f)) * 255);
 
                 return new RGB(r, g, b);
             }


### PR DESCRIPTION
## Summary
- update YCbCr conversion formulas to BT.601 standard coefficients
- correct reverse RGB conversion coefficients

## Testing
- `dotnet build sources/UMapx.csproj`
- `dotnet run --project /tmp/TestYCbCr/TestYCbCr.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c0bffc0a7883219c1a73bb006193e8