### PR TITLE
Fix Db setter clamp to ±1.333

### DIFF
--- a/sources/Colorspace/YDbDr.cs
+++ b/sources/Colorspace/YDbDr.cs
@@ -52,7 +52,7 @@ namespace UMapx.Colorspace
             }
             set
             {
-                db = (value > 1.333) ? 1 : ((value < -1.333) ? -1.333f : value);
+                db = (value > 1.333) ? 1.333f : ((value < -1.333) ? -1.333f : value);
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- Correct Db property in YDbDr color model to clamp values above 1.333 to 1.333f

## Testing
- `dotnet build sources/UMapx.sln`
- `dotnet run --project /tmp/YDbTest/YDbTest.csproj`

------
https://chatgpt.com/codex/tasks/task_e_68c0bfee046c8321b71910ae9491712a