### PR TITLE
Fix Dr formula in YDbDr RGB conversion

### DIFF
--- a/sources/Colorspace/YDbDr.cs
+++ b/sources/Colorspace/YDbDr.cs
@@ -163,7 +163,7 @@ namespace UMapx.Colorspace
 
             float Y = 0.299f * r + 0.587f * g + 0.114f * b;
             float Cb = -0.450f * r - 0.883f * g + 1.333f * b;
-            float Cr = -1.333f * r - 1.116f * g - 0.217f * b;
+            float Cr = -1.333f * r + 1.116f * g + 0.217f * b;
 
             return new YDbDr(Y, Cb, Cr);
         }


### PR DESCRIPTION
## Summary
- Correct Dr component calculation in `YDbDr.FromRGB`

## Testing
- `dotnet build sources/UMapx.csproj`
- `dotnet run` *(sample console app validating RGB to YDbDr conversion)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bfdf11008321af91561c386b69f1