### PR TITLE
Fix saturation handling in HSB color space

### DIFF
--- a/sources/Colorspace/HSB.cs
+++ b/sources/Colorspace/HSB.cs
@@ -53,7 +53,7 @@ namespace UMapx.Colorspace
             }
             set
             {
-                s = (value > 1) ? 1 : ((value < 0.00001f) ? 0.00001f : value);
+                s = (value > 1) ? 1 : ((value < 0) ? 0 : value);
             }
         }
         /// <summary>
@@ -217,8 +217,7 @@ namespace UMapx.Colorspace
                 {
                     red = green = blue = 0;
                 }
-
-                if (s <= 0)
+                else if (s <= 0)
                 {
                     red = green = blue = b;
                 }


### PR DESCRIPTION
## Summary
- Clip `Saturation` to [0,1] range without minimum offset
- Simplify HSB to RGB conversion for zero saturation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c5faeca4832183dbf5e8292896a4