### PR TITLE
Fix green channel conversion in XYZ.ToRGB and clamp output

### DIFF
--- a/sources/Colorspace/XYZ.cs
+++ b/sources/Colorspace/XYZ.cs
@@ -242,13 +242,14 @@ namespace UMapx.Colorspace
             {
                 float[] linear = new float[3];
                 linear[0] = x * 3.2410f - y * 1.5374f - z * 0.4986f; // red
-                linear[1] = -x * 0.9692f + y * 1.8760f - z * 0.0416f; // green
+                linear[1] = -x * 0.9692f + y * 1.8760f + z * 0.0416f; // green
                 linear[2] = x * 0.0556f - y * 0.2040f + z * 1.0570f; // blue
                 float pow = 1.0f / 2.4f;
 
                 for (int i = 0; i < 3; i++)
                 {
                     linear[i] = (linear[i] <= 0.0031308) ? 12.92f * linear[i] : (1 + 0.055f) * Maths.Pow(linear[i], pow) - 0.055f;
+                    linear[i] = Maths.Float(linear[i]);
                 }
 
                 return new RGB(


### PR DESCRIPTION
## Summary
- correct green channel transformation sign in `XYZ.ToRGB`
- clamp linear RGB values to `[0,1]` before creating `RGB`

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c0c5f0df948321a8f3c3c1d3fb4442