### PR TITLE
Fix variance for hyperbolic secant distribution

### DIFF
--- a/sources/Distribution/HyperbolicSecant.cs
+++ b/sources/Distribution/HyperbolicSecant.cs
@@ -35,9 +35,12 @@ namespace UMapx.Distribution
         /// <summary>
         /// Gets the variance value.
         /// </summary>
+        /// <remarks>
+        /// For the standard hyperbolic secant distribution, the variance is π² / 4.
+        /// </remarks>
         public float Variance
         {
-            get { return 1; }
+            get { return Maths.Pow(Maths.Pi, 2) / 4f; }
         }
         /// <summary>
         /// Gets the mode value.


### PR DESCRIPTION
## Summary
- use π²/4 to compute variance of the standard hyperbolic secant distribution
- document variance formula in XML comments

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68c1c652aee4832197114e4d1bc62bd6