### PR TITLE
Fix Sokal-Michener distance normalization

### DIFF
--- a/sources/Distance/SokalMichener.cs
+++ b/sources/Distance/SokalMichener.cs
@@ -30,8 +30,8 @@ namespace UMapx.Distance
                 if (p[i] == 0 && q[i] == 0) ff++;
             }
 
-            int r = 2 * (tf + ft);
-            return r / (float)(ff + tt + r);
+            n = tt + tf + ft + ff;
+            return (tf + ft) / (float)n;
         }
         /// <summary>
         /// Returns distance value.
@@ -55,8 +55,8 @@ namespace UMapx.Distance
                 if (p[i] == 0 && q[i] == 0) ff++;
             }
 
-            int r = 2 * (tf + ft);
-            return r / (float)(ff + tt + r);
+            n = tt + tf + ft + ff;
+            return (tf + ft) / (float)n;
         }
         #endregion
     }


### PR DESCRIPTION
## Summary
- Correct Sokal-Michener distance to compute sample size as tt + tf + ft + ff
- Return mismatches divided by total for both float and complex overloads

## Testing
- `dotnet build` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c6ce9ee80c8321adc750e2f0d943f5