### PR TITLE
Fix Yule distance numerator and denominator

### DIFF
--- a/sources/Distance/Yule.cs
+++ b/sources/Distance/Yule.cs
@@ -30,8 +30,8 @@ namespace UMapx.Distance
                 if (p[i] == 0 && q[i] == 0) ff++;
             }
 
-            float r = 2 * (tf + ft);
-            return r / (tt + ff + r / 2);
+            float r = 2 * tf * ft;
+            return r / (tt * ff + tf * ft);
         }
         /// <summary>
         /// Returns distance value.
@@ -55,8 +55,8 @@ namespace UMapx.Distance
                 if (p[i] == 0 && q[i] == 0) ff++;
             }
 
-            float r = 2 * (tf + ft);
-            return r / (tt + ff + r / 2);
+            float r = 2 * tf * ft;
+            return r / (tt * ff + tf * ft);
         }
         #endregion
     }


### PR DESCRIPTION
## Summary
- Correct Yule distance numerator to use `2 * tf * ft`
- Update denominator to `tt * ff + tf * ft`
- Apply same fix to `Complex32[]` overload

## Testing
- `dotnet test sources/UMapx.sln`
- `dotnet build sources/UMapx.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c6cea1f520832190f0c9da08eee307