### PR TITLE
Handle zero sum in Bray-Curtis distance

### DIFF
--- a/sources/Distance/BrayCurtis.cs
+++ b/sources/Distance/BrayCurtis.cs
@@ -26,6 +26,8 @@ namespace UMapx.Distance
                 y += Math.Abs(p[i] - q[i]);
                 x += Math.Abs(p[i] + q[i]);
             }
+            if (x == 0)
+                return 0f;
 
             return y / x;
         }
@@ -46,6 +48,8 @@ namespace UMapx.Distance
                 y += Maths.Abs(p[i] - q[i]);
                 x += Maths.Abs(p[i] + q[i]);
             }
+            if (x == 0)
+                return 0f;
 
             return y / x;
         }


### PR DESCRIPTION
## Summary
- avoid division by zero in Bray-Curtis distance for real and complex arrays

## Testing
- `dotnet test sources/UMapx.sln` *(fails: Unable to resolve 'NETStandard.Library (>= 2.0.3)' for '.NETStandard,Version=v2.0')*


------
https://chatgpt.com/codex/tasks/task_e_68c6cf900d888321976a08bb34b57c5b