### PR TITLE
Handle zero denominator in Canberra distance

### DIFF
--- a/sources/Distance/Canberra.cs
+++ b/sources/Distance/Canberra.cs
@@ -22,7 +22,9 @@ namespace UMapx.Distance
 
             for (int i = 0; i < n; i++)
             {
-                sum += Math.Abs(p[i] - q[i]) / (Math.Abs(p[i]) + Math.Abs(q[i]));
+                float den = Math.Abs(p[i]) + Math.Abs(q[i]);
+                if (den > 0)
+                    sum += Math.Abs(p[i] - q[i]) / den;
             }
             return sum;
         }
@@ -39,7 +41,9 @@ namespace UMapx.Distance
 
             for (int i = 0; i < n; i++)
             {
-                sum += Maths.Abs(p[i] - q[i]) / (Maths.Abs(p[i]) + Maths.Abs(q[i]));
+                float den = Maths.Abs(p[i]) + Maths.Abs(q[i]);
+                if (den > 0)
+                    sum += Maths.Abs(p[i] - q[i]) / den;
             }
             return sum;
         }


### PR DESCRIPTION
## Summary
- avoid division by zero in Canberra distance for real and complex inputs by checking denominator

## Testing
- `dotnet build sources/UMapx.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c6cfaba638832180d464203d074de1