### PR TITLE
Refactor Jaccard distance counters

### DIFF
--- a/sources/Distance/Jaccard.cs
+++ b/sources/Distance/Jaccard.cs
@@ -17,20 +17,19 @@ namespace UMapx.Distance
         public override float Compute(float[] p, float[] q)
         {
             int n = p.Length;
-            int inter = 0;
-            int union = 0;
+            int tt = 0;
+            int tf = 0;
+            int ft = 0;
 
             for (int i = 0; i < n; i++)
             {
-                if (p[i] != 0 || q[i] != 0)
-                {
-                    if (Maths.Abs(p[i] - q[i]) < 1e-8f)
-                        inter++;
-                    union++;
-                }
+                if (p[i] != 0 && q[i] != 0) tt++;
+                if (p[i] != 0 && q[i] == 0) tf++;
+                if (p[i] == 0 && q[i] != 0) ft++;
             }
 
-            return (union == 0) ? 0 : 1.0f - (inter / (float)union);
+            n = tt + tf + ft;
+            return (n == 0) ? 0f : (tf + ft) / (float)n;
         }
         /// <summary>
         /// Returns distance value.
@@ -41,20 +40,19 @@ namespace UMapx.Distance
         public override Complex32 Compute(Complex32[] p, Complex32[] q)
         {
             int n = p.Length;
-            int inter = 0;
-            int union = 0;
+            int tt = 0;
+            int tf = 0;
+            int ft = 0;
 
             for (int i = 0; i < n; i++)
             {
-                if (p[i] != 0 || q[i] != 0)
-                {
-                    if (Maths.Abs(p[i] - q[i]) < 1e-8f)
-                        inter++;
-                    union++;
-                }
+                if (p[i] != 0 && q[i] != 0) tt++;
+                if (p[i] != 0 && q[i] == 0) tf++;
+                if (p[i] == 0 && q[i] != 0) ft++;
             }
 
-            return (union == 0) ? 0 : 1.0f - (inter / (float)union);
+            n = tt + tf + ft;
+            return (n == 0) ? 0f : (tf + ft) / (float)n;
         }
         #endregion
     }


### PR DESCRIPTION
## Summary
- refactor Jaccard distance to use tt/tf/ft counters
- compute distance with (tf + ft) / (tt + tf + ft)

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c6cf997b348321992b10b6377b31ac