### PR TITLE
Fix angular distance zero denominator handling

### DIFF
--- a/sources/Distance/Angular.cs
+++ b/sources/Distance/Angular.cs
@@ -30,7 +30,7 @@ namespace UMapx.Distance
 
             float den = Maths.Sqrt(x) * Maths.Sqrt(y);
             if (den == 0)
-                return 0;
+                return Maths.Pi / 2;
             float cosine = s / den;
 
             return Maths.Acos(cosine);
@@ -59,8 +59,8 @@ namespace UMapx.Distance
 
             float den = Maths.Sqrt(x) * Maths.Sqrt(y);
             if (den == 0)
-                return 0;
-            Complex32 cosine = s / den;
+                return Maths.Pi / 2;
+            float cosine = Maths.Abs(s) / den;
 
             return Maths.Acos(cosine);
         }


### PR DESCRIPTION
## Summary
- Return π/2 when denominator is zero in Angular distance implementations
- Use magnitude for complex cosine and call Maths.Acos with real value

## Testing
- `dotnet build sources/UMapx.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c6cfb1627c83218fd1c8b289b8a540