### PR TITLE
Handle zero denominator in Dice distance

### DIFF
--- a/sources/Distance/Dice.cs
+++ b/sources/Distance/Dice.cs
@@ -28,7 +28,8 @@ namespace UMapx.Distance
                 if (p[i] != 0 && q[i] != 0) tt++;
             }
 
-            return (tf + ft) / (float)(2 * tt + ft + tf);
+            int den = 2 * tt + ft + tf;
+            return den == 0 ? 0f : (tf + ft) / (float)den;
         }
         /// <summary>
         /// Returns distance value.
@@ -50,7 +51,8 @@ namespace UMapx.Distance
                 if (p[i] != 0 && q[i] != 0) tt++;
             }
 
-            return (tf + ft) / (float)(2.0f * tt + ft + tf);
+            int den = 2 * tt + ft + tf;
+            return den == 0 ? 0f : (tf + ft) / (float)den;
         }
         #endregion
     }


### PR DESCRIPTION
## Summary
- Prevent division-by-zero in Dice distance calculations by computing the denominator after loops and returning 0 when it is zero for both float and Complex32 inputs

## Testing
- `dotnet build sources/UMapx.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c6d0eb9b408321876e9990c2c8c6a0