### PR TITLE
Fix Sokal–Sneath distance formula

### DIFF
--- a/sources/Distance/SokalSneath.cs
+++ b/sources/Distance/SokalSneath.cs
@@ -28,8 +28,8 @@ namespace UMapx.Distance
                 if (p[i] != 0 && q[i] != 0) tt++;
             }
 
-            int r = 2 * (tf + ft);
-            return r / (float)(tt + r);
+            int denominator = 2 * tt + tf + ft;
+            return denominator == 0 ? 0f : (2f * (tf + ft)) / denominator;
         }
         /// <summary>
         /// Returns distance value.
@@ -51,8 +51,8 @@ namespace UMapx.Distance
                 if (p[i] != 0 && q[i] != 0) tt++;
             }
 
-            int r = 2 * (tf + ft);
-            return r / (float)(tt + r);
+            int denominator = 2 * tt + tf + ft;
+            return denominator == 0 ? 0f : (2f * (tf + ft)) / denominator;
         }
         #endregion
     }


### PR DESCRIPTION
## Summary
- correct Sokal–Sneath distance calculation to use `(2f*(tf+ft))/(2*tt+tf+ft)` and guard against division by zero
- apply the same logic to Complex32 overload

## Testing
- `dotnet build sources/UMapx.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c6d0f3877c83219f8e3157ebf959b1