### PR TITLE
Handle Beta mode boundaries

### DIFF
--- a/sources/Distribution/Beta.cs
+++ b/sources/Distribution/Beta.cs
@@ -101,12 +101,24 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode value. If <c>a ≤ 1</c> and <c>b > 1</c>,
+        /// the mode is at 0. If <c>b ≤ 1</c> and <c>a > 1</c>,
+        /// the mode is at 1. When both parameters are greater than
+        /// one, the mode is calculated as <c>(a - 1) / (a + b - 2)</c>;
+        /// otherwise, the mode is undefined and returns <see cref="float.NaN" />.
         /// </summary>
         public float Mode
         {
             get
             {
+                if (a <= 1 && b > 1)
+                {
+                    return 0f;
+                }
+                if (b <= 1 && a > 1)
+                {
+                    return 1f;
+                }
                 if (a > 1 && b > 1)
                 {
                     return (a - 1) / (a + b - 2);


### PR DESCRIPTION
## Summary
- handle Beta distribution mode edge cases by returning 0 when a ≤ 1 < b and 1 when b ≤ 1 < a
- document boundary behavior for mode calculation

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c6d232b3dc83219c1126881d9e5e0a