### PR TITLE
Handle Burr distribution mean divergence

### DIFF
--- a/sources/Distribution/Burr.cs
+++ b/sources/Distribution/Burr.cs
@@ -64,13 +64,16 @@ namespace UMapx.Distribution
         }
         /// <summary>
         /// Gets the mean value.
+        /// Mean does not exist for k ≤ 1/c.
         /// </summary>
         public float Mean
         {
-            get 
+            get
             {
-                if (k <= 1.0f / c) return float.NaN;
-                return k * Special.Beta(k - 1.0f / c, 1.0f + 1.0f / c); 
+                if (k <= 1.0f / c)
+                    return float.PositiveInfinity; // mean does not exist for k ≤ 1/c
+
+                return k * Special.Beta(k - 1.0f / c, 1.0f + 1.0f / c);
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- return `float.PositiveInfinity` when Burr distribution mean diverges
- document that the mean does not exist for `k ≤ 1/c`

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c6d4c1c0548321adad35f08a4be5a7