### PR TITLE
Fix wrapped Cauchy variance expression

### DIFF
--- a/sources/Distribution/WrappedCauchy.cs
+++ b/sources/Distribution/WrappedCauchy.cs
@@ -73,7 +73,7 @@ namespace UMapx.Distribution
         /// </summary>
         public float Variance
         {
-            get { return 1 - Maths.Exp(-2 * gamma); } // circular variance
+            get { return 1f - Maths.Exp(-gamma); } // returns circular variance
         }
         /// <summary>
         /// Gets the median value.


### PR DESCRIPTION
## Summary
- fix circular variance calculation for WrappedCauchy distribution
- clarify comment that the property returns circular variance

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68c6d68d1ddc83219f79fb932b17fa8e