### PR TITLE
Handle infinite variance for BetaPrime distribution

### DIFF
--- a/sources/Distribution/BetaPrime.cs
+++ b/sources/Distribution/BetaPrime.cs
@@ -110,7 +110,7 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the variance value.
+        /// Gets the variance value. When <c>β ≤ 2</c>, the variance does not exist (∞).
         /// </summary>
         public float Variance
         {
@@ -122,12 +122,9 @@ namespace UMapx.Distribution
                     float den = (beta - 2) * Maths.Pow(beta - 1, 2);
                     return num / den;
                 }
-                else if (beta > 1.0)
-                {
-                    return float.PositiveInfinity;
-                }
 
-                return float.NaN;
+                // β ≤ 2: variance does not exist (∞)
+                return float.PositiveInfinity;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- document that variance is infinite when β ≤ 2 in BetaPrime distribution
- return `float.PositiveInfinity` instead of `NaN` when β ≤ 2

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c71b2c5fac8321853f02c06fea5ed3