### PR TITLE
Clarify integer count in binomial CDF

### DIFF
--- a/sources/Distribution/Binomial.cs
+++ b/sources/Distribution/Binomial.cs
@@ -183,8 +183,10 @@ namespace UMapx.Distribution
             if (x >= n)
                 return 1;
 
-            float a = n - x;
-            float b = x + 1;
+            // Interpret x as the integer number of successes k.
+            int k = (int)Maths.Floor(x);
+            float a = n - k;
+            float b = k + 1;
             return Special.BetaIncompleteRegularized(a, b, q);
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- interpret CDF input as integer number of successes before Beta calculation
- reuse floored value for BetaIncompleteRegularized parameters

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c71e76c59c8321af7756282e5a5970