### PR TITLE
Fix Pareto excess formula

### DIFF
--- a/sources/Distribution/Pareto.cs
+++ b/sources/Distribution/Pareto.cs
@@ -145,13 +145,16 @@ namespace UMapx.Distribution
         /// <summary>
         /// Gets the kurtosis coefficient.
         /// </summary>
+        /// <remarks>
+        /// Formula: 6 * (k^3 + k^2 - 6k - 2) / (k * (k - 3) * (k - 4))
+        /// </remarks>
         public float Excess
         {
             get
             {
                 float k2 = k * k;
                 float k3 = k2 * k;
-                return 6 * (k3 + k2 + 6 * k - 2) / (k * (k - 3) * (k - 4));
+                return 6 * (k3 + k2 - 6 * k - 2) / (k * (k - 3) * (k - 4));
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- correct numerator in Pareto kurtosis calculation
- document fixed formula in remarks

## Testing
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c7208749b08321a0ff55bcf4821d5b