### PR TITLE
Clamp cosine in Angular distance

### DIFF
--- a/sources/Distance/Angular.cs
+++ b/sources/Distance/Angular.cs
@@ -32,6 +32,8 @@ namespace UMapx.Distance
             if (den == 0)
                 return Maths.Pi / 2;
             float cosine = s / den;
+            // clamp cosine for numerical stability
+            cosine = Maths.Max(-1f, Maths.Min(1f, cosine));
 
             return Maths.Acos(cosine);
         }
@@ -61,6 +63,8 @@ namespace UMapx.Distance
             if (den == 0)
                 return Maths.Pi / 2;
             float cosine = Maths.Abs(s) / den;
+            // clamp cosine for numerical stability
+            cosine = Maths.Max(-1f, Maths.Min(1f, cosine));
 
             return Maths.Acos(cosine);
         }


### PR DESCRIPTION
## Summary
- clamp cosine to [-1,1] for numerical stability in Angular distance computations
## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c7209f0cfc8321b2c1a4889d6089b1