### PR TITLE
Fix variance of HyperbolicSecant distribution

### DIFF
--- a/sources/Distribution/HyperbolicSecant.cs
+++ b/sources/Distribution/HyperbolicSecant.cs
@@ -36,11 +36,11 @@ namespace UMapx.Distribution
         /// Gets the variance value.
         /// </summary>
         /// <remarks>
-        /// For the standard hyperbolic secant distribution, the variance is π² / 4.
+        /// For the standard hyperbolic secant distribution, the variance equals 1.
         /// </remarks>
         public float Variance
         {
-            get { return Maths.Pow(Maths.Pi, 2) / 4f; }
+            get { return 1f; }
         }
         /// <summary>
         /// Gets the mode value.


### PR DESCRIPTION
## Summary
- correct HyperbolicSecant variance to 1
- remove misleading variance comment

## Testing
- `dotnet build sources/UMapx.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68c723f45ae483219cad206fe943f213