### PR TITLE
Fix Gompertz normalization factor

### DIFF
--- a/sources/Distribution/Gompertz.cs
+++ b/sources/Distribution/Gompertz.cs
@@ -154,7 +154,8 @@ namespace UMapx.Distribution
                 return 0;
             }
 
-            float a1 = b * eta * Maths.Exp(eta);
+            // Normalization does not contain factor exp(η).
+            float a1 = b * eta;
             float a2 = Maths.Exp(b * x);
             float a3 = Maths.Exp(-eta * Maths.Exp(b * x));
             return a1 * a2 * a3;


### PR DESCRIPTION
## Summary
- remove extraneous `exp(η)` factor in Gompertz PDF computation
- document that the normalization excludes the `exp(η)` factor

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c723f210cc83219dc92a165dbe61b2