### PR TITLE
Clarify kurtosis documentation

### DIFF
--- a/sources/Distribution/Arcsine.cs
+++ b/sources/Distribution/Arcsine.cs
@@ -54,8 +54,11 @@ namespace UMapx.Distribution
             get { return 0; }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { return -1.5f; }

--- a/sources/Distribution/Bernoulli.cs
+++ b/sources/Distribution/Bernoulli.cs
@@ -131,9 +131,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the excess kurtosis.
-        /// The returned value already equals kurtosis minus 3.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Beta.cs
+++ b/sources/Distribution/Beta.cs
@@ -144,8 +144,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/BetaPrime.cs
+++ b/sources/Distribution/BetaPrime.cs
@@ -135,8 +135,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/Binomial.cs
+++ b/sources/Distribution/Binomial.cs
@@ -142,8 +142,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/BirnbaumSaunders.cs
+++ b/sources/Distribution/BirnbaumSaunders.cs
@@ -130,8 +130,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/Burr.cs
+++ b/sources/Distribution/Burr.cs
@@ -114,8 +114,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/Cauchy.cs
+++ b/sources/Distribution/Cauchy.cs
@@ -116,8 +116,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/ChiSquare.cs
+++ b/sources/Distribution/ChiSquare.cs
@@ -109,8 +109,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/ChoiWilliams.cs
+++ b/sources/Distribution/ChoiWilliams.cs
@@ -76,8 +76,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/ConeShape.cs
+++ b/sources/Distribution/ConeShape.cs
@@ -76,8 +76,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/Erlang.cs
+++ b/sources/Distribution/Erlang.cs
@@ -123,8 +123,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Exponential.cs
+++ b/sources/Distribution/Exponential.cs
@@ -108,8 +108,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/FisherSnedecor.cs
+++ b/sources/Distribution/FisherSnedecor.cs
@@ -155,8 +155,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/FisherZ.cs
+++ b/sources/Distribution/FisherZ.cs
@@ -101,8 +101,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/Gamma.cs
+++ b/sources/Distribution/Gamma.cs
@@ -128,8 +128,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Gaussian.cs
+++ b/sources/Distribution/Gaussian.cs
@@ -125,8 +125,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Geometric.cs
+++ b/sources/Distribution/Geometric.cs
@@ -107,8 +107,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Gompertz.cs
+++ b/sources/Distribution/Gompertz.cs
@@ -107,8 +107,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/Gumbel.cs
+++ b/sources/Distribution/Gumbel.cs
@@ -119,6 +119,9 @@ namespace UMapx.Distribution
         /// <summary>
         /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/HyperbolicSecant.cs
+++ b/sources/Distribution/HyperbolicSecant.cs
@@ -59,6 +59,9 @@ namespace UMapx.Distribution
         /// <summary>
         /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { return -1f; }

--- a/sources/Distribution/Hypergeometric.cs
+++ b/sources/Distribution/Hypergeometric.cs
@@ -147,8 +147,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/IDistribution.cs
+++ b/sources/Distribution/IDistribution.cs
@@ -33,8 +33,11 @@ namespace UMapx.Distribution
         /// </summary>
         float Skewness { get; }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         float Excess { get; }
         /// <summary>
         /// Returns the value of differential entropy.

--- a/sources/Distribution/Kumaraswamy.cs
+++ b/sources/Distribution/Kumaraswamy.cs
@@ -140,8 +140,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/Laplace.cs
+++ b/sources/Distribution/Laplace.cs
@@ -125,8 +125,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Levy.cs
+++ b/sources/Distribution/Levy.cs
@@ -108,8 +108,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/LogGaussian.cs
+++ b/sources/Distribution/LogGaussian.cs
@@ -125,8 +125,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/LogLogistic.cs
+++ b/sources/Distribution/LogLogistic.cs
@@ -119,8 +119,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/Logarithmic.cs
+++ b/sources/Distribution/Logarithmic.cs
@@ -97,8 +97,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/Logistic.cs
+++ b/sources/Distribution/Logistic.cs
@@ -118,8 +118,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Nakagami.cs
+++ b/sources/Distribution/Nakagami.cs
@@ -150,8 +150,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }

--- a/sources/Distribution/Pareto.cs
+++ b/sources/Distribution/Pareto.cs
@@ -143,9 +143,10 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
         /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
         /// Formula: 6 * (k^3 + k^2 - 6k - 2) / (k * (k - 3) * (k - 4))
         /// </remarks>
         public float Excess

--- a/sources/Distribution/Poisson.cs
+++ b/sources/Distribution/Poisson.cs
@@ -108,8 +108,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Rademacher.cs
+++ b/sources/Distribution/Rademacher.cs
@@ -70,8 +70,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Rayleigh.cs
+++ b/sources/Distribution/Rayleigh.cs
@@ -110,8 +110,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Student.cs
+++ b/sources/Distribution/Student.cs
@@ -112,12 +112,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
         /// <remarks>
-        /// For degrees of freedom in the interval (2, 4], the kurtosis is infinite and
+        /// Full kurtosis equals 3 plus this value.
+        /// For degrees of freedom in the interval (2, 4], the excess kurtosis is infinite and
         /// returns <see cref="float.PositiveInfinity"/>. For degrees of freedom ≤ 2, the
-        /// kurtosis is undefined and returns <see cref="float.NaN"/>.
+        /// excess kurtosis is undefined and returns <see cref="float.NaN"/>.
         /// </remarks>
         public float Excess
         {

--- a/sources/Distribution/Triangular.cs
+++ b/sources/Distribution/Triangular.cs
@@ -140,8 +140,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/UQuadratic.cs
+++ b/sources/Distribution/UQuadratic.cs
@@ -118,8 +118,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Uniform.cs
+++ b/sources/Distribution/Uniform.cs
@@ -122,8 +122,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Weibull.cs
+++ b/sources/Distribution/Weibull.cs
@@ -128,8 +128,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the excess coefficient (kurtosis minus 3).
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/Wigner.cs
+++ b/sources/Distribution/Wigner.cs
@@ -104,8 +104,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get

--- a/sources/Distribution/WrappedCauchy.cs
+++ b/sources/Distribution/WrappedCauchy.cs
@@ -104,8 +104,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the kurtosis coefficient.
+        /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
         public float Excess
         {
             get { throw new NotSupportedException(); }


### PR DESCRIPTION
## Summary
- standardize distribution docs to say "excess kurtosis (kurtosis minus 3)"
- document relation to full kurtosis in remarks

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c725b642a0832199890a7aab5bf584