### PR TITLE
Update geometric distribution excess kurtosis

### DIFF
--- a/sources/Distribution/Geometric.cs
+++ b/sources/Distribution/Geometric.cs
@@ -107,7 +107,7 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// Returns the excess kurtosis (kurtosis minus 3).
         /// </summary>
         /// <remarks>
         /// Full kurtosis equals 3 plus this value.
@@ -116,7 +116,7 @@ namespace UMapx.Distribution
         {
             get
             {
-                return 6 + p * p / q;
+                return p * p / q + 3f;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- compute geometric distribution excess kurtosis with new expression
- clarify comment to state the property returns excess kurtosis (kurtosis minus 3)

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c727b6f8248321a4e655ffdd288b89