### PR TITLE
Clamp Chi-square median

### DIFF
--- a/sources/Distribution/ChiSquare.cs
+++ b/sources/Distribution/ChiSquare.cs
@@ -64,14 +64,18 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the median value (approximation).
+        /// Gets the median value using the Wilson–Hilferty approximation.
         /// </summary>
+        /// <remarks>
+        /// The approximation is truncated to zero for very small degrees of freedom.
+        /// </remarks>
         public float Median
         {
             get
             {
-                // Wilson–Hilferty approximation to keep median non-negative
-                return k * Maths.Pow(1 - 2f / (9f * k), 3f);
+                // Wilson–Hilferty approximation
+                float median = k * Maths.Pow(1 - 2f / (9f * k), 3f);
+                return median < 0f ? 0f : median;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure Chi-square median stays non-negative by truncating Wilson–Hilferty approximation at zero
- document approximation and truncation

## Testing
- `dotnet build sources/UMapx.sln`


------
https://chatgpt.com/codex/tasks/task_e_68c72dfd82cc832195f3d5ec0bce61ae