### PR TITLE
Handle undefined skewness in Binomial distribution

### DIFF
--- a/sources/Distribution/Binomial.cs
+++ b/sources/Distribution/Binomial.cs
@@ -134,10 +134,15 @@ namespace UMapx.Distribution
         /// <summary>
         /// Gets the value of the asymmetry coefficient.
         /// </summary>
+        /// <remarks>
+        /// Skewness is undefined when all trials succeed or fail.
+        /// </remarks>
         public float Skewness
         {
             get
             {
+                if (p == 0f || p == 1f)
+                    return float.NaN;
                 return (q - p) / Maths.Sqrt(n * p * q);
             }
         }


### PR DESCRIPTION
## Summary
- handle degenerate binomial cases by returning `float.NaN` when all trials succeed or fail
- document that skewness is undefined when `p` is 0 or 1

## Testing
- `dotnet test sources/UMapx.sln` (no test projects found)
- `dotnet build sources/UMapx.sln`

------
https://chatgpt.com/codex/tasks/task_e_68c72e1aefd083219b5f44a56738dd8e