### PR TITLE
Adjust hyperbolic secant entropy constant

### DIFF
--- a/sources/Distribution/HyperbolicSecant.cs
+++ b/sources/Distribution/HyperbolicSecant.cs
@@ -77,11 +77,11 @@ namespace UMapx.Distribution
         /// Returns the value of differential entropy.
         /// </summary>
         /// <remarks>
-        /// This value corresponds to the hyperbolic secant distribution with scale σ = 1.
+        /// This value corresponds to the hyperbolic secant distribution with the variance-1 (σ = 1) parametrization.
         /// </remarks>
         public float Entropy
         {
-            get { return Maths.Log(4f); }
+            get { return Maths.Log(2 * Maths.Pi); }
         }
         /// <summary>
         /// Returns the value of the probability distribution function.


### PR DESCRIPTION
## Summary
- update the hyperbolic secant entropy constant to use log(2π)
- clarify the entropy remark to refer to the variance-1 parametrization

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c868af9644832194ca4a4315e3a7b6