### PR TITLE
Fix geometric excess kurtosis

### DIFF
--- a/sources/Distribution/Geometric.cs
+++ b/sources/Distribution/Geometric.cs
@@ -110,13 +110,13 @@ namespace UMapx.Distribution
         /// Gets the excess kurtosis (kurtosis minus 3).
         /// </summary>
         /// <remarks>
-        /// Full kurtosis equals 3 plus this value.
+        /// The full kurtosis equals this value plus 3.
         /// </remarks>
         public float Excess
         {
             get
             {
-                return p * p / q + 3f;
+                return p * p / q;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- ensure the geometric distribution's Excess property returns the excess kurtosis by removing the added constant term
- clarify the XML documentation remark to describe how to obtain the full kurtosis

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c868ab1a508321bb7fa3c6ad761145