### PR TITLE
Set wrapped Cauchy mode to location parameter

### DIFF
--- a/sources/Distribution/WrappedCauchy.cs
+++ b/sources/Distribution/WrappedCauchy.cs
@@ -83,11 +83,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the circular mode, which equals the location parameter μ.
         /// </summary>
         public float Mode
         {
-            get { throw new NotSupportedException(); }
+            get { return mu; }
         }
         /// <summary>
         /// Gets the support interval of the argument.


### PR DESCRIPTION
## Summary
- update the WrappedCauchy.Mode property to return the location parameter
- clarify the mode documentation to state it equals μ

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8699b905c8321bbe785f9a789b1a5