### PR TITLE
Fix Nakagami mode calculation

### DIFF
--- a/sources/Distribution/Nakagami.cs
+++ b/sources/Distribution/Nakagami.cs
@@ -114,13 +114,13 @@ namespace UMapx.Distribution
         }
         /// <summary>
         /// Gets the mode value.
-        /// The mode is calculated as <c>sqrt((2 * μ - 1) * ω / μ)</c>.
+        /// The mode is calculated as <c>sqrt((2 * μ - 1) * ω / (2 * μ))</c>.
         /// </summary>
         public float Mode
         {
             get
             {
-                return Maths.Sqrt((2 * mu - 1) * omega / mu);
+                return Maths.Sqrt((2 * mu - 1) * omega / (2 * mu));
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- correct the Nakagami mode formula to divide by 2μ and update its XML documentation comment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c86b036fd883219d13d02cc52f0b5a