### PR TITLE
Fix Gompertz variance expression

### DIFF
--- a/sources/Distribution/Gompertz.cs
+++ b/sources/Distribution/Gompertz.cs
@@ -76,6 +76,9 @@ namespace UMapx.Distribution
         /// <summary>
         /// Gets the variance value.
         /// </summary>
+        /// <remarks>
+        /// Variance equals (2·e^{η}·E₁(η) − e^{η}·E₁(2η) − e^{η}·E₁(η)²) / b².
+        /// </remarks>
         public float Variance
         {
             get
@@ -83,8 +86,7 @@ namespace UMapx.Distribution
                 float e1 = -Special.Ei(-eta);
                 float e2 = -Special.Ei(-2f * eta);
                 float expEta = Maths.Exp(eta);
-                float exp2Eta = expEta * expEta;
-                return (2f * expEta * e1 - exp2Eta * e2 - exp2Eta * e1 * e1) / (b * b);
+                return (2f * expEta * e1 - expEta * e2 - expEta * e1 * e1) / (b * b);
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- document the closed form of the Gompertz variance
- correct the variance calculation to use exp(η) consistently

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8706945a88321afc3d2046134d9b3