### PR TITLE
Update distribution mode properties to return arrays

### DIFF
--- a/sources/Distribution/Arcsine.cs
+++ b/sources/Distribution/Arcsine.cs
@@ -40,11 +40,11 @@ namespace UMapx.Distribution
             get { return 1.0f / 8; }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
-            get { return float.NaN; }
+            get { return new float[] { 0f, 1f }; }
         }
         /// <summary>
         /// Gets the value of the asymmetry coefficient.

--- a/sources/Distribution/Bernoulli.cs
+++ b/sources/Distribution/Bernoulli.cs
@@ -80,21 +80,22 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
                 if (q > p)
                 {
-                    return 0;
+                    return new float[] { 0f };
                 }
                 else if (q < p)
                 {
-                    return 1;
+                    return new float[] { 1f };
                 }
-                return 0.5f;
+
+                return new float[] { 0f, 1f };
             }
         }
         /// <summary>

--- a/sources/Distribution/Beta.cs
+++ b/sources/Distribution/Beta.cs
@@ -101,29 +101,46 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value. If <c>a ≤ 1</c> and <c>b > 1</c>,
-        /// the mode is at 0. If <c>b ≤ 1</c> and <c>a > 1</c>,
+        /// Gets the mode values. If <c>a ≤ 1</c> and <c>b ≥ 1</c>,
+        /// the mode is at 0. If <c>b ≤ 1</c> and <c>a ≥ 1</c>,
         /// the mode is at 1. When both parameters are greater than
-        /// one, the mode is calculated as <c>(a - 1) / (a + b - 2)</c>;
-        /// otherwise, the mode is undefined and returns <see cref="float.NaN" />.
+        /// one, the mode is calculated as <c>(a - 1) / (a + b - 2)</c>.
+        /// If both parameters are less than one, the distribution is bimodal
+        /// with modes at the boundaries 0 and 1. When both parameters equal
+        /// one, the mode is undefined and represented by <see cref="float.NaN" />.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                if (a <= 1 && b > 1)
+                const float eps = 1e-6f;
+
+                if (a < 1f && b < 1f)
                 {
-                    return 0f;
+                    return new float[] { 0f, 1f };
                 }
-                if (b <= 1 && a > 1)
+
+                bool approxA1 = Maths.Abs(a - 1f) < eps;
+                bool approxB1 = Maths.Abs(b - 1f) < eps;
+
+                if (approxA1 && approxB1)
                 {
-                    return 1f;
+                    return new float[] { float.NaN };
                 }
-                if (a > 1 && b > 1)
+
+                if (a <= 1f && b >= 1f)
                 {
-                    return (a - 1) / (a + b - 2);
+                    return new float[] { 0f };
                 }
-                return float.NaN;
+                if (b <= 1f && a >= 1f)
+                {
+                    return new float[] { 1f };
+                }
+                if (a > 1f && b > 1f)
+                {
+                    return new float[] { (a - 1f) / (a + b - 2f) };
+                }
+                return new float[] { float.NaN };
             }
         }
         /// <summary>

--- a/sources/Distribution/BetaPrime.cs
+++ b/sources/Distribution/BetaPrime.cs
@@ -95,18 +95,18 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
                 if (alpha >= 1)
                 {
-                    return (alpha - 1) / (beta + 1);
+                    return new float[] { (alpha - 1) / (beta + 1) };
                 }
 
-                return 0.0f;
+                return new float[] { 0.0f };
             }
         }
         /// <summary>

--- a/sources/Distribution/Binomial.cs
+++ b/sources/Distribution/Binomial.cs
@@ -99,24 +99,43 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
                 float test = (n + 1) * p;
 
-                if (test <= 0 || (int)test != test)
-                    return Maths.Floor(test);
+                if (test <= 0f)
+                {
+                    return new float[] { 0f };
+                }
 
-                if (test <= n)
-                    return test;
+                if (test >= n + 1f)
+                {
+                    return new float[] { n };
+                }
 
-                if (test == n + 1)
-                    return n;
+                float floor = Maths.Floor(test);
+                float rounded = Maths.Round(test);
 
-                return float.NaN;
+                if (Maths.Abs(test - rounded) < 1e-6f)
+                {
+                    if (rounded <= 0f)
+                    {
+                        return new float[] { 0f };
+                    }
+
+                    if (rounded >= n + 1f)
+                    {
+                        return new float[] { n };
+                    }
+
+                    return new float[] { rounded - 1f, rounded };
+                }
+
+                return new float[] { floor };
             }
         }
         /// <summary>

--- a/sources/Distribution/BirnbaumSaunders.cs
+++ b/sources/Distribution/BirnbaumSaunders.cs
@@ -134,12 +134,12 @@ namespace UMapx.Distribution
             get { return beta * beta * gamma * gamma * (1 + 5f * gamma * gamma / 4f); }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
         /// <remarks>
         /// Derived from solving a cubic equation; valid for γ &gt; 0.
         /// </remarks>
-        public float Mode
+        public float[] Mode
         {
             get
             {
@@ -149,12 +149,16 @@ namespace UMapx.Distribution
                 float p = b - a * a / 3f;
                 float q = 2f * a * a * a / 27f - a * b / 3f + 1f;
                 float d = q * q / 4f + p * p * p / 27f;
-                if (d < 0) return float.NaN;
+                if (d < 0)
+                {
+                    return new float[] { float.NaN };
+                }
+
                 float sqrt = Maths.Sqrt(d);
                 float u = Cbrt(-q / 2f + sqrt);
                 float v = Cbrt(-q / 2f - sqrt);
                 float t = u + v - a / 3f;
-                return mu + beta * t;
+                return new float[] { mu + beta * t };
             }
         }
         /// <summary>

--- a/sources/Distribution/Burr.cs
+++ b/sources/Distribution/Burr.cs
@@ -99,16 +99,16 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
                 if (c > 1)
-                    return Maths.Pow((c - 1) / (k * c + 1), 1.0f / c);
+                    return new float[] { Maths.Pow((c - 1) / (k * c + 1), 1.0f / c) };
 
-                return 0;
+                return new float[] { 0f };
             }
         }
         /// <summary>

--- a/sources/Distribution/Cauchy.cs
+++ b/sources/Distribution/Cauchy.cs
@@ -89,13 +89,13 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return x0;
+                return new float[] { x0 };
             }
         }
         /// <summary>

--- a/sources/Distribution/ChiSquare.cs
+++ b/sources/Distribution/ChiSquare.cs
@@ -79,17 +79,17 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
                 if (k >= 2)
                 {
-                    return k - 2;
+                    return new float[] { k - 2f };
                 }
-                return 0;
+                return new float[] { 0f };
             }
         }
         /// <summary>

--- a/sources/Distribution/ChoiWilliams.cs
+++ b/sources/Distribution/ChoiWilliams.cs
@@ -62,9 +62,9 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get { throw new NotSupportedException(); }
         }

--- a/sources/Distribution/ConeShape.cs
+++ b/sources/Distribution/ConeShape.cs
@@ -62,9 +62,9 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get { throw new NotSupportedException(); }
         }

--- a/sources/Distribution/Erlang.cs
+++ b/sources/Distribution/Erlang.cs
@@ -103,13 +103,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return (this.k - 1) / this.lambda;
+                return new float[] { (this.k - 1f) / this.lambda };
             }
         }
         /// <summary>

--- a/sources/Distribution/Exponential.cs
+++ b/sources/Distribution/Exponential.cs
@@ -78,13 +78,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return 0.0f;
+                return new float[] { 0.0f };
             }
         }
         /// <summary>

--- a/sources/Distribution/FisherSnedecor.cs
+++ b/sources/Distribution/FisherSnedecor.cs
@@ -117,12 +117,12 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
         /// <remarks>
         /// When <c>d1 ≤ 2</c>, the mode occurs at zero.
         /// </remarks>
-        public float Mode
+        public float[] Mode
         {
             get
             {
@@ -130,10 +130,10 @@ namespace UMapx.Distribution
                 {
                     float a = (d1 - 2.0f) / d1;
                     float b = d2 / (d2 + 2.0f);
-                    return a * b;
+                    return new float[] { a * b };
                 }
 
-                return 0f;
+                return new float[] { 0f };
             }
         }
         /// <summary>

--- a/sources/Distribution/FisherZ.cs
+++ b/sources/Distribution/FisherZ.cs
@@ -93,13 +93,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return 0;
+                return new float[] { 0f };
             }
         }
         /// <summary>

--- a/sources/Distribution/Gamma.cs
+++ b/sources/Distribution/Gamma.cs
@@ -97,17 +97,17 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
                 if (k >= 1)
                 {
-                    return (k - 1) * thetta;
+                    return new float[] { (k - 1) * thetta };
                 }
-                return 0;
+                return new float[] { 0 };
             }
         }
         /// <summary>

--- a/sources/Distribution/Gaussian.cs
+++ b/sources/Distribution/Gaussian.cs
@@ -105,13 +105,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return this.mu;
+                return new float[] { this.mu };
             }
         }
         /// <summary>

--- a/sources/Distribution/Geometric.cs
+++ b/sources/Distribution/Geometric.cs
@@ -80,13 +80,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return 0;
+                return new float[] { 0f };
             }
         }
         /// <summary>

--- a/sources/Distribution/Gompertz.cs
+++ b/sources/Distribution/Gompertz.cs
@@ -88,16 +88,16 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
                 if (eta >= 1)
-                    return 0;
+                    return new float[] { 0f };
 
-                return (1 / b) * Maths.Log(1 / eta);
+                return new float[] { (1 / b) * Maths.Log(1 / eta) };
             }
         }
         /// <summary>

--- a/sources/Distribution/Gumbel.cs
+++ b/sources/Distribution/Gumbel.cs
@@ -97,13 +97,13 @@ namespace UMapx.Distribution
             get { return (float)((Math.PI * Math.PI) / 6.0) * beta * beta; }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return mu;
+                return new float[] { mu };
             }
         }
         /// <summary>

--- a/sources/Distribution/HyperbolicSecant.cs
+++ b/sources/Distribution/HyperbolicSecant.cs
@@ -43,11 +43,11 @@ namespace UMapx.Distribution
             get { return 1f; }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
-            get { return 0; }
+            get { return new float[] { 0f }; }
         }
         /// <summary>
         /// Gets the value of the asymmetry coefficient.

--- a/sources/Distribution/Hypergeometric.cs
+++ b/sources/Distribution/Hypergeometric.cs
@@ -122,15 +122,51 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                float num = (k + 1) * (d + 1);
-                float den = n + 2;
-                return Maths.Floor(num / den);
+                float value = ((k + 1f) * (d + 1f)) / (n + 2f);
+                float lower = Maths.Max(0f, k + d - n);
+                float upper = Maths.Min(d, k);
+
+                float floor = Maths.Range(Maths.Floor(value), lower, upper);
+                float rounded = Maths.Round(value);
+
+                if (Maths.Abs(value - rounded) < 1e-6f)
+                {
+                    float candidate1 = rounded - 1f;
+                    float candidate2 = rounded;
+                    bool firstValid = candidate1 >= lower - 1e-6f && candidate1 <= upper + 1e-6f;
+                    bool secondValid = candidate2 >= lower - 1e-6f && candidate2 <= upper + 1e-6f;
+
+                    if (firstValid && secondValid)
+                    {
+                        float mode1 = Maths.Range(candidate1, lower, upper);
+                        float mode2 = Maths.Range(candidate2, lower, upper);
+
+                        if (Maths.Abs(mode1 - mode2) < 1e-6f)
+                        {
+                            return new float[] { mode1 };
+                        }
+
+                        return new float[] { mode1, mode2 };
+                    }
+
+                    if (firstValid)
+                    {
+                        return new float[] { Maths.Range(candidate1, lower, upper) };
+                    }
+
+                    if (secondValid)
+                    {
+                        return new float[] { Maths.Range(candidate2, lower, upper) };
+                    }
+                }
+
+                return new float[] { floor };
             }
         }
         /// <summary>

--- a/sources/Distribution/IDistribution.cs
+++ b/sources/Distribution/IDistribution.cs
@@ -25,9 +25,9 @@ namespace UMapx.Distribution
         /// </summary>
         float Median { get; }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        float Mode { get; }
+        float[] Mode { get; }
         /// <summary>
         /// Gets the value of the asymmetry coefficient.
         /// </summary>

--- a/sources/Distribution/Kumaraswamy.cs
+++ b/sources/Distribution/Kumaraswamy.cs
@@ -99,30 +99,45 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                if (a < 1 && b >= 1)
+                const float eps = 1e-6f;
+
+                bool approxA1 = Maths.Abs(a - 1f) < eps;
+                bool approxB1 = Maths.Abs(b - 1f) < eps;
+
+                if (a < 1f && b < 1f)
                 {
-                    return 0f;
+                    return new float[] { 0f, 1f };
                 }
 
-                if (b < 1 && a >= 1)
+                if (approxA1 && approxB1)
                 {
-                    return 1f;
+                    return new float[] { float.NaN };
                 }
 
-                if ((a >= 1) && (b >= 1) && (a != 1 && b != 1))
+                if (a <= 1f && b >= 1f)
                 {
-                    float num = a - 1;
-                    float den = a * b - 1;
-                    return Maths.Pow(num / den, 1 / a);
+                    return new float[] { 0f };
                 }
 
-                return float.NaN;
+                if (a >= 1f && b <= 1f)
+                {
+                    return new float[] { 1f };
+                }
+
+                if (a > 1f && b > 1f)
+                {
+                    float num = a - 1f;
+                    float den = a * b - 1f;
+                    return new float[] { Maths.Pow(num / den, 1f / a) };
+                }
+
+                return new float[] { float.NaN };
             }
         }
         /// <summary>

--- a/sources/Distribution/Laplace.cs
+++ b/sources/Distribution/Laplace.cs
@@ -95,13 +95,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return b;
+                return new float[] { b };
             }
         }
         /// <summary>

--- a/sources/Distribution/Levy.cs
+++ b/sources/Distribution/Levy.cs
@@ -91,13 +91,13 @@ namespace UMapx.Distribution
             get { return float.PositiveInfinity; }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return mu + scale / 3.0f;
+                return new float[] { mu + scale / 3.0f };
             }
         }
         /// <summary>

--- a/sources/Distribution/LogGaussian.cs
+++ b/sources/Distribution/LogGaussian.cs
@@ -105,13 +105,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return Maths.Exp(mu - sigma * sigma);
+                return new float[] { Maths.Exp(mu - sigma * sigma) };
             }
         }
         /// <summary>

--- a/sources/Distribution/LogLogistic.cs
+++ b/sources/Distribution/LogLogistic.cs
@@ -91,17 +91,17 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
                 if (b > 1)
                 {
-                    return a * Maths.Pow((b - 1) / (b + 1), 1 / b);
+                    return new float[] { a * Maths.Pow((b - 1) / (b + 1), 1 / b) };
                 }
-                return 0;
+                return new float[] { 0 };
             }
         }
         /// <summary>

--- a/sources/Distribution/Logarithmic.cs
+++ b/sources/Distribution/Logarithmic.cs
@@ -83,11 +83,11 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
-            get { return 1; }
+            get { return new float[] { 1f }; }
         }
         /// <summary>
         /// Gets the value of the asymmetry coefficient.

--- a/sources/Distribution/Logistic.cs
+++ b/sources/Distribution/Logistic.cs
@@ -101,11 +101,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
-            get { return mu; }
+            get { return new float[] { mu }; }
         }
         /// <summary>
         /// Gets the value of the asymmetry coefficient.

--- a/sources/Distribution/Nakagami.cs
+++ b/sources/Distribution/Nakagami.cs
@@ -113,14 +113,21 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
-        /// The mode is calculated as <c>sqrt((2 * μ - 1) * ω / (2 * μ))</c>.
+        /// Gets the mode values.
+        /// The mode is calculated as <c>sqrt((2 * μ - 1) * ω / (2 * μ))</c> when defined.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return Maths.Sqrt((2 * mu - 1) * omega / (2 * mu));
+                float value = (2 * mu - 1f) * omega / (2 * mu);
+
+                if (value <= 0f)
+                {
+                    return new float[] { 0f };
+                }
+
+                return new float[] { Maths.Sqrt(value) };
             }
         }
         /// <summary>

--- a/sources/Distribution/Pareto.cs
+++ b/sources/Distribution/Pareto.cs
@@ -109,13 +109,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return xm;
+                return new float[] { xm };
             }
         }
         /// <summary>

--- a/sources/Distribution/Poisson.cs
+++ b/sources/Distribution/Poisson.cs
@@ -78,13 +78,20 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return Maths.Floor(l);
+                float mode = Maths.Floor(l);
+
+                if (mode > 0f && Maths.Abs(l - mode) < 1e-6f)
+                {
+                    return new float[] { mode - 1f, mode };
+                }
+
+                return new float[] { mode };
             }
         }
         /// <summary>

--- a/sources/Distribution/Rademacher.cs
+++ b/sources/Distribution/Rademacher.cs
@@ -53,11 +53,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
-            get { return float.NaN; }
+            get { return new float[] { -1f, 1f }; }
         }
         /// <summary>
         /// Gets the value of the asymmetry coefficient.

--- a/sources/Distribution/Rayleigh.cs
+++ b/sources/Distribution/Rayleigh.cs
@@ -90,13 +90,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return sigma;
+                return new float[] { sigma };
             }
         }
         /// <summary>

--- a/sources/Distribution/Student.cs
+++ b/sources/Distribution/Student.cs
@@ -88,13 +88,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return 0;
+                return new float[] { 0f };
             }
         }
         /// <summary>

--- a/sources/Distribution/Triangular.cs
+++ b/sources/Distribution/Triangular.cs
@@ -121,11 +121,11 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
-            get { return c; }
+            get { return new float[] { c }; }
         }
         /// <summary>
         /// Gets the value of the asymmetry coefficient.

--- a/sources/Distribution/UQuadratic.cs
+++ b/sources/Distribution/UQuadratic.cs
@@ -77,13 +77,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return (int)a & (int)b;
+                return new float[] { (int)a & (int)b };
             }
         }
         /// <summary>

--- a/sources/Distribution/Uniform.cs
+++ b/sources/Distribution/Uniform.cs
@@ -91,14 +91,14 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value. Since the uniform distribution has no unique mode,
+        /// Gets the mode values. Since the uniform distribution has no unique mode,
         /// the value is undefined and represented by <see cref="float.NaN"/>.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return float.NaN;
+                return new float[] { float.NaN };
             }
         }
         /// <summary>

--- a/sources/Distribution/Weibull.cs
+++ b/sources/Distribution/Weibull.cs
@@ -98,13 +98,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return k > 1 ? l * Maths.Pow((k - 1f) / k, 1f / k) : 0f;
+                return new float[] { k > 1 ? l * Maths.Pow((k - 1f) / k, 1f / k) : 0f };
             }
         }
         /// <summary>

--- a/sources/Distribution/Wigner.cs
+++ b/sources/Distribution/Wigner.cs
@@ -84,13 +84,13 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the mode value.
+        /// Gets the mode values.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
             get
             {
-                return 0;
+                return new float[] { 0f };
             }
         }
         /// <summary>

--- a/sources/Distribution/WrappedCauchy.cs
+++ b/sources/Distribution/WrappedCauchy.cs
@@ -85,9 +85,9 @@ namespace UMapx.Distribution
         /// <summary>
         /// Gets the circular mode, which equals the location parameter μ.
         /// </summary>
-        public float Mode
+        public float[] Mode
         {
-            get { return mu; }
+            get { return new float[] { mu }; }
         }
         /// <summary>
         /// Gets the support interval of the argument.


### PR DESCRIPTION
## Summary
- change the `IDistribution.Mode` contract to return all modes as an array
- update every distribution implementation to emit arrays, including logic for multi-modal cases such as Bernoulli, Binomial, Poisson, Beta/Kumaraswamy, Hypergeometric, Rademacher, and Arcsine

## Testing
- `dotnet build UMapx.sln` *(fails: dotnet CLI is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68c87f00fa08832197fa321c324f6db6