### PR TITLE
Fix hypergeometric variance formula

### DIFF
--- a/sources/Distribution/Hypergeometric.cs
+++ b/sources/Distribution/Hypergeometric.cs
@@ -111,6 +111,9 @@ namespace UMapx.Distribution
         /// <summary>
         /// Gets the variance value.
         /// </summary>
+        /// <remarks>
+        /// Variance equals d * (k / n) * ((n - k) / n) * ((n - d) / (n - 1)).
+        /// </remarks>
         public float Variance
         {
             get
@@ -118,7 +121,7 @@ namespace UMapx.Distribution
                 if (n <= 1f)
                     return 0f;
 
-                return k * (d / n) * ((n - d) / n) * ((n - k) / (n - 1.0f));
+                return d * (k / n) * ((n - k) / n) * ((n - d) / (n - 1f));
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- correct the hypergeometric variance formula implementation
- document the variance expression in the XML comments

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c88c896e2c8321b1bc1b9348b4ecb3