### PR TITLE
Fix FisherZ variance condition

### DIFF
--- a/sources/Distribution/FisherZ.cs
+++ b/sources/Distribution/FisherZ.cs
@@ -82,14 +82,15 @@ namespace UMapx.Distribution
         /// Gets the variance value.
         /// </summary>
         /// <remarks>
-        /// The variance is finite only when <c>d2 &gt; 4</c>;
-        /// otherwise, <see cref="float.PositiveInfinity"/> is returned.
+        /// The variance is finite only when <c>d2 &gt; 4</c>, explicitly requiring
+        /// that the second degree of freedom exceeds 4; otherwise,
+        /// <see cref="float.PositiveInfinity"/> is returned.
         /// </remarks>
         public float Variance
         {
             get
             {
-                return (d2 > 4) ? 2f * (d1 + d2 - 2f) / (d1 * (d2 - 2f)) : float.PositiveInfinity;
+                return (d2 > 4) ? 2f * (d1 + d2 - 2f) / (d1 * (d2 - 4f)) : float.PositiveInfinity;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- adjust the FisherZ variance expression to use the correct d2 - 4 denominator
- clarify the variance documentation to emphasize the requirement d2 must exceed 4

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c88e69ff6c83218a9c6eef74edc10c