### PR TITLE
Restrict hypergeometric PMF to integer arguments

### DIFF
--- a/sources/Distribution/Hypergeometric.cs
+++ b/sources/Distribution/Hypergeometric.cs
@@ -216,16 +216,26 @@ namespace UMapx.Distribution
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>
+        /// <remarks>
+        /// The function is defined only for integer values of <paramref name="x"/>.
+        /// </remarks>
         public float Function(float x)
         {
-            if (x < Math.Max(0, k + d - n) || x > Math.Min(d, k))
+            if (x != Math.Floor(x))
             {
-                return 0;
+                return 0f;
             }
 
-            double a = Special.Binomial(d, x);
-            double b = Special.Binomial(n - d, k - x);
-            double c = Special.Binomial(n, k);
+            int k = (int)x;
+
+            if (k < Math.Max(0, this.k + d - n) || k > Math.Min(d, this.k))
+            {
+                return 0f;
+            }
+
+            double a = Special.Binomial(d, k);
+            double b = Special.Binomial(n - d, this.k - k);
+            double c = Special.Binomial(n, this.k);
             return (float)(a * b / c);
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- return zero for non-integer inputs before evaluating the hypergeometric PMF
- compute the PMF with an integer version of the argument and clarify field usage
- document that the PMF is defined only for integer arguments

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8903a16d08321ab0c9edf4e9a581a