### PR TITLE
Fix Gumbel excess kurtosis

### DIFF
--- a/sources/Distribution/Gumbel.cs
+++ b/sources/Distribution/Gumbel.cs
@@ -117,7 +117,7 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// Gets the distribution's excess kurtosis (kurtosis excess, i.e. kurtosis minus 3).
         /// </summary>
         /// <remarks>
         /// Full kurtosis equals 3 plus this value.
@@ -126,7 +126,7 @@ namespace UMapx.Distribution
         {
             get
             {
-                return 12.0f / 5 - 3f;
+                return 12.0f / 5f;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- correct the Gumbel distribution's excess kurtosis constant to 12/5
- clarify that the Excess property returns the distribution's excess kurtosis

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c89028dfe883218a5bd29f5d7a9090