### PR TITLE
Fix Poisson CDF for zero case

### DIFF
--- a/sources/Distribution/Poisson.cs
+++ b/sources/Distribution/Poisson.cs
@@ -155,7 +155,7 @@ namespace UMapx.Distribution
                 return 0;
             }
             x = Maths.Floor(x);
-            return Special.GammaP(x + 1, l);
+            return Special.GammaQ(x + 1, l);
         }
         /// <summary>
         /// Returns the value of differential entropy.


### PR DESCRIPTION
## Summary
- use the upper regularized gamma function for the Poisson CDF to match the expected discrete probability

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c894b5df6c83219f4d2b5d513f842e