### PR TITLE
Fix geometric excess kurtosis calculation

### DIFF
--- a/sources/Distribution/Geometric.cs
+++ b/sources/Distribution/Geometric.cs
@@ -116,7 +116,7 @@ namespace UMapx.Distribution
         {
             get
             {
-                return 6f + p * p / q;
+                return 3f + p * p / q;
             }
         }
         /// <summary>


### PR DESCRIPTION
## Summary
- correct the excess kurtosis calculation for the geometric distribution to subtract 3 instead of 6

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c894f149cc8321bc6e1adab486c279