### PR TITLE
Add inverse-related continuous distributions

### DIFF
--- a/sources/Distribution/FoldedNormal.cs
+++ b/sources/Distribution/FoldedNormal.cs
@@ -1,0 +1,227 @@
+using System;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the folded normal distribution.
+    /// </summary>
+    /// <remarks>
+    /// More information can be found on the website:
+    /// https://en.wikipedia.org/wiki/Folded_normal_distribution
+    /// </remarks>
+    [Serializable]
+    public class FoldedNormal : IDistribution
+    {
+        #region Private data
+        private float mu = 0f;
+        private float sigma = 1f;
+        #endregion
+
+        #region Folded normal components
+        /// <summary>
+        /// Initializes the folded normal distribution.
+        /// </summary>
+        public FoldedNormal() { }
+        /// <summary>
+        /// Initializes the folded normal distribution.
+        /// </summary>
+        /// <param name="mu">Mean value of the underlying Gaussian variable.</param>
+        /// <param name="sigma">Standard deviation of the underlying Gaussian variable.</param>
+        public FoldedNormal(float mu, float sigma)
+        {
+            Mu = mu;
+            Sigma = sigma;
+        }
+        /// <summary>
+        /// Gets or sets the mean value of the underlying Gaussian variable.
+        /// </summary>
+        public float Mu
+        {
+            get { return this.mu; }
+            set { this.mu = value; }
+        }
+        /// <summary>
+        /// Gets or sets the standard deviation of the underlying Gaussian variable.
+        /// </summary>
+        public float Sigma
+        {
+            get { return this.sigma; }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentException("Invalid argument value");
+
+                this.sigma = value;
+            }
+        }
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get { return new RangeFloat(0, float.PositiveInfinity); }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean
+        {
+            get
+            {
+                double sigma2 = sigma * sigma;
+                double coeff = sigma * Math.Sqrt(2.0 / Math.PI) * Math.Exp(-(mu * mu) / (2.0 * sigma2));
+                double corr = mu * (1.0 - 2.0 * StandardNormalCdf(-mu / sigma));
+                return (float)(coeff + corr);
+            }
+        }
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance
+        {
+            get
+            {
+                double mean = Mean;
+                return (float)(mu * mu + sigma * sigma - mean * mean);
+            }
+        }
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median
+        {
+            get
+            {
+                return FindQuantile(0.5f);
+            }
+        }
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode
+        {
+            get { return new float[] { ComputeMode() }; }
+        }
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness
+        {
+            get { return float.NaN; }
+        }
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess
+        {
+            get { return float.NaN; }
+        }
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x)
+        {
+            if (x < 0)
+            {
+                return 0f;
+            }
+
+            double a = (x - mu) / sigma;
+            double b = (-x - mu) / sigma;
+            return (float)((StandardNormalPdf(a) + StandardNormalPdf(b)) / sigma);
+        }
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x)
+        {
+            if (x <= 0)
+            {
+                return 0f;
+            }
+
+            double den = Math.Sqrt(2.0) * sigma;
+            double a = (x + mu) / den;
+            double b = (x - mu) / den;
+            return (float)(0.5 * (Special.Erf((float)a) + Special.Erf((float)b)));
+        }
+        /// <summary>
+        /// Returns the value of differential entropy.
+        /// </summary>
+        /// <returns>Value</returns>
+        public float Entropy
+        {
+            get { throw new NotSupportedException(); }
+        }
+        #endregion
+
+        #region Private methods
+        private static double StandardNormalPdf(double z)
+        {
+            return Math.Exp(-0.5 * z * z) / Math.Sqrt(2.0 * Math.PI);
+        }
+
+        private static double StandardNormalCdf(double z)
+        {
+            return 0.5 * (1.0 + Special.Erf((float)(z / Math.Sqrt(2.0))));
+        }
+
+        private float ComputeMode()
+        {
+            if (sigma == 0)
+            {
+                return 0f;
+            }
+
+            double absMu = Math.Abs(mu);
+            if (absMu == 0)
+            {
+                return 0f;
+            }
+
+            double ratio = absMu / sigma;
+            double exponent = -absMu * absMu / (2.0 * sigma * sigma);
+            double arg = ratio * ratio * Math.Exp(exponent);
+            if (arg <= 0)
+            {
+                return 0f;
+            }
+
+            double w = Special.LambertW((float)arg);
+            double value = sigma / Math.Sqrt(2.0) * Math.Sqrt(w + ratio * ratio);
+            return (float)value;
+        }
+
+        private float FindQuantile(float p)
+        {
+            if (p <= 0f)
+                return 0f;
+            if (p >= 1f)
+                return float.PositiveInfinity;
+
+            double lower = 0.0;
+            double upper = Math.Abs(mu) + 10.0 * sigma + 10.0;
+
+            for (int i = 0; i < 50; i++)
+            {
+                double mid = 0.5 * (lower + upper);
+                double cdf = Distribution((float)mid);
+                if (cdf > p)
+                    upper = mid;
+                else
+                    lower = mid;
+            }
+
+            return (float)(0.5 * (lower + upper));
+        }
+        #endregion
+    }
+}

--- a/sources/Distribution/GeneralizedNormal.cs
+++ b/sources/Distribution/GeneralizedNormal.cs
@@ -1,0 +1,180 @@
+using System;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the generalized normal distribution (version 1 / exponential power distribution).
+    /// </summary>
+    /// <remarks>
+    /// More information can be found on the website:
+    /// https://en.wikipedia.org/wiki/Generalized_normal_distribution
+    /// </remarks>
+    [Serializable]
+    public class GeneralizedNormal : IDistribution
+    {
+        #region Private data
+        private float mu = 0f;
+        private float alpha = 1f;
+        private float beta = 2f;
+        #endregion
+
+        #region Generalized normal components
+        /// <summary>
+        /// Initializes the generalized normal distribution.
+        /// </summary>
+        public GeneralizedNormal() { }
+        /// <summary>
+        /// Initializes the generalized normal distribution.
+        /// </summary>
+        /// <param name="mu">Location parameter.</param>
+        /// <param name="alpha">Scale parameter (0, +inf).</param>
+        /// <param name="beta">Shape parameter (0, +inf).</param>
+        public GeneralizedNormal(float mu, float alpha, float beta)
+        {
+            Mu = mu;
+            Alpha = alpha;
+            Beta = beta;
+        }
+        /// <summary>
+        /// Gets or sets the location parameter.
+        /// </summary>
+        public float Mu
+        {
+            get { return this.mu; }
+            set { this.mu = value; }
+        }
+        /// <summary>
+        /// Gets or sets the scale parameter (0, +inf).
+        /// </summary>
+        public float Alpha
+        {
+            get { return this.alpha; }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentException("Invalid argument value");
+
+                this.alpha = value;
+            }
+        }
+        /// <summary>
+        /// Gets or sets the shape parameter (0, +inf).
+        /// </summary>
+        public float Beta
+        {
+            get { return this.beta; }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentException("Invalid argument value");
+
+                this.beta = value;
+            }
+        }
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get { return new RangeFloat(float.NegativeInfinity, float.PositiveInfinity); }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean
+        {
+            get { return this.mu; }
+        }
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance
+        {
+            get
+            {
+                float ratio = Special.Gamma(3f / beta) / Special.Gamma(1f / beta);
+                return alpha * alpha * ratio;
+            }
+        }
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median
+        {
+            get { return this.mu; }
+        }
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode
+        {
+            get { return new float[] { this.mu }; }
+        }
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness
+        {
+            get { return 0f; }
+        }
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess
+        {
+            get
+            {
+                float g1 = Special.Gamma(5f / beta);
+                float g2 = Special.Gamma(1f / beta);
+                float g3 = Special.Gamma(3f / beta);
+                float kurtosis = (g1 * g2) / (g3 * g3);
+                return kurtosis - 3f;
+            }
+        }
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x)
+        {
+            float z = Maths.Abs((x - mu) / alpha);
+            float norm = beta / (2f * alpha * Special.Gamma(1f / beta));
+            return norm * Maths.Exp(-Maths.Pow(z, beta));
+        }
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x)
+        {
+            float z = x - mu;
+            if (z == 0f)
+                return 0.5f;
+
+            float sign = z > 0 ? 1f : -1f;
+            float u = Maths.Pow(Maths.Abs(z) / alpha, beta);
+            float p = Special.GammaP(1f / beta, u);
+            return 0.5f + 0.5f * sign * p;
+        }
+        /// <summary>
+        /// Returns the value of differential entropy.
+        /// </summary>
+        /// <returns>Value</returns>
+        public float Entropy
+        {
+            get
+            {
+                float a = 1f / beta;
+                float norm = beta / (2f * alpha * Special.Gamma(a));
+                return a - Maths.Log(norm);
+            }
+        }
+        #endregion
+    }
+}

--- a/sources/Distribution/InverseChiSquare.cs
+++ b/sources/Distribution/InverseChiSquare.cs
@@ -1,0 +1,152 @@
+using System;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the inverse chi-square distribution.
+    /// </summary>
+    /// <remarks>
+    /// More information can be found on the website:
+    /// https://en.wikipedia.org/wiki/Inverse-chi-squared_distribution
+    /// </remarks>
+    [Serializable]
+    public class InverseChiSquare : IDistribution
+    {
+        #region Private data
+        private int v = 1;
+        #endregion
+
+        #region Inverse chi-square components
+        /// <summary>
+        /// Initializes the inverse chi-square distribution.
+        /// </summary>
+        public InverseChiSquare() { }
+        /// <summary>
+        /// Initializes the inverse chi-square distribution.
+        /// </summary>
+        /// <param name="degreesOfFreedom">Degrees of freedom (positive integer).</param>
+        public InverseChiSquare(int degreesOfFreedom)
+        {
+            V = degreesOfFreedom;
+        }
+        /// <summary>
+        /// Gets or sets the degrees of freedom (positive integer).
+        /// </summary>
+        public int V
+        {
+            get { return this.v; }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentException("Invalid argument value");
+
+                this.v = value;
+            }
+        }
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get { return new RangeFloat(0f, float.PositiveInfinity); }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean
+        {
+            get
+            {
+                if (v > 2)
+                    return 1f / (v - 2f);
+                return float.NaN;
+            }
+        }
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance
+        {
+            get
+            {
+                if (v > 4)
+                    return (v - 2f) * (v - 2f) * (v - 4f);
+                return float.NaN;
+            }
+        }
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median
+        {
+            get { return float.NaN; }
+        }
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode
+        {
+            get { return new float[] { 1f / (v + 2f) }; }
+        }
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness
+        {
+            get { return float.NaN; }
+        }
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess
+        {
+            get { return float.NaN; }
+        }
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x)
+        {
+            if (x <= 0f)
+                return 0f;
+
+            float vf = v;
+            float a = Maths.Pow(2f, -vf / 2f);
+            float b = Maths.Pow(x, -vf / 2f - 1f);
+            float c = Maths.Exp(-1f / (2f * x));
+            float d = Special.Gamma(vf / 2f);
+            return (a * b * c) / d;
+        }
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x)
+        {
+            if (x <= 0f)
+                return 0f;
+
+            return Special.GammaQ(v / 2f, 1f / (2f * x));
+        }
+        /// <summary>
+        /// Returns the value of differential entropy.
+        /// </summary>
+        /// <returns>Value</returns>
+        public float Entropy
+        {
+            get
+            {
+                float vf = v;
+                return vf / 2f + Maths.Log(0.5f) + Special.LogGamma(vf / 2f) - (1f - vf / 2f) * Special.DiGamma(vf / 2f);
+            }
+        }
+        #endregion
+    }
+}

--- a/sources/Distribution/InverseGamma.cs
+++ b/sources/Distribution/InverseGamma.cs
@@ -1,0 +1,183 @@
+using System;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the inverse gamma distribution.
+    /// </summary>
+    /// <remarks>
+    /// More information can be found on the website:
+    /// https://en.wikipedia.org/wiki/Inverse-gamma_distribution
+    /// </remarks>
+    [Serializable]
+    public class InverseGamma : IDistribution
+    {
+        #region Private data
+        private float alpha = 1f;
+        private float beta = 1f;
+        private float constant = 1f;
+        #endregion
+
+        #region Inverse gamma components
+        /// <summary>
+        /// Initializes the inverse gamma distribution.
+        /// </summary>
+        public InverseGamma()
+        {
+            UpdateConstant();
+        }
+        /// <summary>
+        /// Initializes the inverse gamma distribution.
+        /// </summary>
+        /// <param name="alpha">Shape parameter α (0, +inf).</param>
+        /// <param name="beta">Scale parameter β (0, +inf).</param>
+        public InverseGamma(float alpha, float beta)
+        {
+            Alpha = alpha;
+            Beta = beta;
+        }
+        /// <summary>
+        /// Gets or sets the shape parameter α (0, +inf).
+        /// </summary>
+        public float Alpha
+        {
+            get { return this.alpha; }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentException("Invalid argument value");
+
+                this.alpha = value;
+                UpdateConstant();
+            }
+        }
+        /// <summary>
+        /// Gets or sets the scale parameter β (0, +inf).
+        /// </summary>
+        public float Beta
+        {
+            get { return this.beta; }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentException("Invalid argument value");
+
+                this.beta = value;
+                UpdateConstant();
+            }
+        }
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get { return new RangeFloat(float.Epsilon, float.PositiveInfinity); }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean
+        {
+            get
+            {
+                if (alpha <= 1f)
+                    return float.PositiveInfinity;
+                return beta / (alpha - 1f);
+            }
+        }
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance
+        {
+            get
+            {
+                if (alpha <= 2f)
+                    return float.PositiveInfinity;
+                float denom = (alpha - 1f) * (alpha - 1f) * (alpha - 2f);
+                return (beta * beta) / denom;
+            }
+        }
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median
+        {
+            get { return float.NaN; }
+        }
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode
+        {
+            get { return new float[] { beta / (alpha + 1f) }; }
+        }
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness
+        {
+            get { return alpha > 3f ? (4f * Maths.Sqrt(alpha - 2f)) / (alpha - 3f) : float.NaN; }
+        }
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess
+        {
+            get
+            {
+                if (alpha <= 4f)
+                    return float.NaN;
+
+                float a = alpha;
+                float num = 6f * (a * a * a + a * a - 6f * a - 2f);
+                float den = a * (a - 3f) * (a - 4f);
+                return num / den;
+            }
+        }
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x)
+        {
+            if (x <= 0f)
+                return 0f;
+
+            return constant * Maths.Pow(x, -alpha - 1f) * Maths.Exp(-beta / x);
+        }
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x)
+        {
+            if (x <= 0f)
+                return 0f;
+
+            return Special.GammaQ(alpha, beta / x);
+        }
+        /// <summary>
+        /// Returns the value of differential entropy.
+        /// </summary>
+        /// <returns>Value</returns>
+        public float Entropy
+        {
+            get { return alpha + Maths.Log(beta) + Special.LogGamma(alpha) - (1f + alpha) * Special.DiGamma(alpha); }
+        }
+        #endregion
+
+        #region Private methods
+        private void UpdateConstant()
+        {
+            this.constant = Maths.Pow(beta, alpha) / Special.Gamma(alpha);
+        }
+        #endregion
+    }
+}

--- a/sources/Distribution/InverseGaussian.cs
+++ b/sources/Distribution/InverseGaussian.cs
@@ -1,0 +1,187 @@
+using System;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the inverse Gaussian (Wald) distribution.
+    /// </summary>
+    /// <remarks>
+    /// More information can be found on the website:
+    /// https://en.wikipedia.org/wiki/Inverse_Gaussian_distribution
+    /// </remarks>
+    [Serializable]
+    public class InverseGaussian : IDistribution
+    {
+        #region Private data
+        private float mu = 1f;
+        private float lambda = 1f;
+        #endregion
+
+        #region Inverse Gaussian components
+        /// <summary>
+        /// Initializes the inverse Gaussian distribution.
+        /// </summary>
+        public InverseGaussian() { }
+        /// <summary>
+        /// Initializes the inverse Gaussian distribution.
+        /// </summary>
+        /// <param name="mu">Mean parameter μ (0, +inf).</param>
+        /// <param name="lambda">Shape parameter λ (0, +inf).</param>
+        public InverseGaussian(float mu, float lambda)
+        {
+            Mu = mu;
+            Lambda = lambda;
+        }
+        /// <summary>
+        /// Gets or sets the mean parameter μ (0, +inf).
+        /// </summary>
+        public float Mu
+        {
+            get { return this.mu; }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentException("Invalid argument value");
+
+                this.mu = value;
+            }
+        }
+        /// <summary>
+        /// Gets or sets the shape parameter λ (0, +inf).
+        /// </summary>
+        public float Lambda
+        {
+            get { return this.lambda; }
+            set
+            {
+                if (value <= 0)
+                    throw new ArgumentException("Invalid argument value");
+
+                this.lambda = value;
+            }
+        }
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get { return new RangeFloat(0f, float.PositiveInfinity); }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean
+        {
+            get { return this.mu; }
+        }
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance
+        {
+            get { return mu * mu * mu / lambda; }
+        }
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median
+        {
+            get { return FindQuantile(0.5f); }
+        }
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode
+        {
+            get
+            {
+                double ratio = (3.0 * mu) / (2.0 * lambda);
+                double term = Math.Sqrt(1.0 + (9.0 * mu * mu) / (4.0 * lambda * lambda));
+                double mode = mu * (term - ratio);
+                return new float[] { (float)mode };
+            }
+        }
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness
+        {
+            get { return 3f * Maths.Sqrt(mu / lambda); }
+        }
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess
+        {
+            get { return 15f * mu / lambda; }
+        }
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x)
+        {
+            if (x <= 0f)
+                return 0f;
+
+            double coef = Math.Sqrt(lambda / (2.0 * Math.PI * x * x * x));
+            double expo = -lambda * Math.Pow(x - mu, 2) / (2.0 * mu * mu * x);
+            return (float)(coef * Math.Exp(expo));
+        }
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x)
+        {
+            if (x <= 0f)
+                return 0f;
+
+            double sqrt = Math.Sqrt(lambda / x);
+            double a = 0.5 * Special.Erfc((float)(sqrt * (mu - x) / (Maths.Sqrt2 * mu)));
+            double b = 0.5 * Special.Erfc((float)(sqrt * (mu + x) / (Maths.Sqrt2 * mu)));
+            double c = Math.Exp((2.0 * lambda) / mu);
+            return (float)(a + b * c);
+        }
+        /// <summary>
+        /// Returns the value of differential entropy.
+        /// </summary>
+        /// <returns>Value</returns>
+        public float Entropy
+        {
+            get { throw new NotSupportedException(); }
+        }
+        #endregion
+
+        #region Private methods
+        private float FindQuantile(float p)
+        {
+            if (p <= 0f)
+                return 0f;
+            if (p >= 1f)
+                return float.PositiveInfinity;
+
+            double lower = 0.0;
+            double upper = mu + 10.0 * Math.Sqrt(Variance) + 10.0;
+
+            for (int i = 0; i < 60; i++)
+            {
+                double mid = 0.5 * (lower + upper);
+                double cdf = Distribution((float)mid);
+                if (cdf > p)
+                    upper = mid;
+                else
+                    lower = mid;
+            }
+
+            return (float)(0.5 * (lower + upper));
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary
- add folded normal distribution with CDF, PDF and quantile helpers
- implement generalized normal distribution using gamma and incomplete gamma functions
- port inverse chi-square, inverse gamma and inverse Gaussian distributions including parameter validation and statistics

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c93d2bed788321b6a53fbc11567284