### PR TITLE
Add wrappers for Accord distributions

### DIFF
--- a/sources/Distribution/AndersonDarling.cs
+++ b/sources/Distribution/AndersonDarling.cs
@@ -1,0 +1,91 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the Anderson-Darling distribution.
+    /// </summary>
+    [Serializable]
+    public class AndersonDarling : IDistribution
+    {
+        #region Private data
+        private AndersonDarlingDistribution distribution;
+        #endregion
+
+        #region AndersonDarling components
+        /// <summary>
+        /// Initializes the Anderson-Darling distribution.
+        /// </summary>
+        /// <param name="type">Compared distribution type.</param>
+        /// <param name="samples">Number of samples.</param>
+        public AndersonDarling(AndersonDarlingDistributionType type, float samples)
+        {
+            distribution = new AndersonDarlingDistribution(type, samples);
+        }
+        /// <summary>
+        /// Gets Anderson-Darling distribution type.
+        /// </summary>
+        public AndersonDarlingDistributionType DistributionType => distribution.DistributionType;
+        /// <summary>
+        /// Gets the number of samples.
+        /// </summary>
+        public float Samples => (float)distribution.NumberOfSamples;
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => throw new NotSupportedException();
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/DistributionHelper.cs
+++ b/sources/Distribution/DistributionHelper.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace UMapx.Distribution
+{
+    internal static class DistributionHelper
+    {
+        public static double[] ToDouble(float[] values)
+        {
+            if (values == null)
+            {
+                return null;
+            }
+
+            double[] result = new double[values.Length];
+            for (int i = 0; i < values.Length; i++)
+            {
+                result[i] = values[i];
+            }
+            return result;
+        }
+
+        public static float[] ToFloat(double[] values)
+        {
+            if (values == null)
+            {
+                return null;
+            }
+
+            float[] result = new float[values.Length];
+            for (int i = 0; i < values.Length; i++)
+            {
+                result[i] = (float)values[i];
+            }
+            return result;
+        }
+    }
+}

--- a/sources/Distribution/Empirical.cs
+++ b/sources/Distribution/Empirical.cs
@@ -1,0 +1,145 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the empirical distribution.
+    /// </summary>
+    [Serializable]
+    public class Empirical : IDistribution
+    {
+        #region Private data
+        private EmpiricalDistribution distribution;
+        #endregion
+
+        #region Empirical components
+        /// <summary>
+        /// Initializes the empirical distribution from samples.
+        /// </summary>
+        /// <param name="samples">Samples.</param>
+        public Empirical(float[] samples)
+        {
+            distribution = new EmpiricalDistribution(DistributionHelper.ToDouble(samples));
+        }
+        /// <summary>
+        /// Initializes the empirical distribution from samples with smoothing parameter.
+        /// </summary>
+        /// <param name="samples">Samples.</param>
+        /// <param name="smoothing">Smoothing parameter.</param>
+        public Empirical(float[] samples, float smoothing)
+        {
+            distribution = new EmpiricalDistribution(DistributionHelper.ToDouble(samples), smoothing);
+        }
+        /// <summary>
+        /// Initializes the empirical distribution from samples with fractional weights.
+        /// </summary>
+        /// <param name="samples">Samples.</param>
+        /// <param name="weights">Fractional weights.</param>
+        public Empirical(float[] samples, float[] weights)
+        {
+            distribution = new EmpiricalDistribution(DistributionHelper.ToDouble(samples), DistributionHelper.ToDouble(weights));
+        }
+        /// <summary>
+        /// Initializes the empirical distribution from samples with repetition weights.
+        /// </summary>
+        /// <param name="samples">Samples.</param>
+        /// <param name="weights">Repetition weights.</param>
+        public Empirical(float[] samples, int[] weights)
+        {
+            distribution = new EmpiricalDistribution(DistributionHelper.ToDouble(samples), weights);
+        }
+        /// <summary>
+        /// Initializes the empirical distribution from samples with fractional weights and smoothing parameter.
+        /// </summary>
+        /// <param name="samples">Samples.</param>
+        /// <param name="weights">Fractional weights.</param>
+        /// <param name="smoothing">Smoothing parameter.</param>
+        public Empirical(float[] samples, float[] weights, float smoothing)
+        {
+            distribution = new EmpiricalDistribution(DistributionHelper.ToDouble(samples), DistributionHelper.ToDouble(weights), smoothing);
+        }
+        /// <summary>
+        /// Initializes the empirical distribution from samples with repetition weights and smoothing parameter.
+        /// </summary>
+        /// <param name="samples">Samples.</param>
+        /// <param name="weights">Repetition weights.</param>
+        /// <param name="smoothing">Smoothing parameter.</param>
+        public Empirical(float[] samples, int[] weights, float smoothing)
+        {
+            distribution = new EmpiricalDistribution(DistributionHelper.ToDouble(samples), weights, smoothing);
+        }
+        /// <summary>
+        /// Gets smoothing parameter.
+        /// </summary>
+        public float Smoothing => (float)distribution.Smoothing;
+        /// <summary>
+        /// Gets samples.
+        /// </summary>
+        public float[] Samples => DistributionHelper.ToFloat(distribution.Samples);
+        /// <summary>
+        /// Gets fractional weights.
+        /// </summary>
+        public float[] Weights => DistributionHelper.ToFloat(distribution.Weights);
+        /// <summary>
+        /// Gets repetition counts.
+        /// </summary>
+        public int[] Counts => distribution.Counts;
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => (float)distribution.Mean;
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => (float)distribution.Variance;
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => new[] { (float)distribution.Mode };
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => (float)distribution.Entropy;
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/EmpiricalHazard.cs
+++ b/sources/Distribution/EmpiricalHazard.cs
@@ -1,0 +1,124 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the empirical hazard distribution.
+    /// </summary>
+    [Serializable]
+    public class EmpiricalHazard : IDistribution
+    {
+        #region Private data
+        private EmpiricalHazardDistribution distribution;
+        #endregion
+
+        #region EmpiricalHazard components
+        /// <summary>
+        /// Initializes the empirical hazard distribution.
+        /// </summary>
+        public EmpiricalHazard()
+        {
+            distribution = new EmpiricalHazardDistribution();
+        }
+        /// <summary>
+        /// Initializes the empirical hazard distribution with times and hazard values.
+        /// </summary>
+        /// <param name="times">Times.</param>
+        /// <param name="hazards">Hazard rates.</param>
+        public EmpiricalHazard(float[] times, float[] hazards)
+        {
+            distribution = new EmpiricalHazardDistribution(DistributionHelper.ToDouble(times), DistributionHelper.ToDouble(hazards));
+        }
+        /// <summary>
+        /// Initializes the empirical hazard distribution with estimator.
+        /// </summary>
+        /// <param name="times">Times.</param>
+        /// <param name="hazards">Hazard rates.</param>
+        /// <param name="estimator">Survival estimator.</param>
+        public EmpiricalHazard(float[] times, float[] hazards, SurvivalEstimator estimator)
+        {
+            distribution = new EmpiricalHazardDistribution(DistributionHelper.ToDouble(times), DistributionHelper.ToDouble(hazards), estimator);
+        }
+        /// <summary>
+        /// Initializes the empirical hazard distribution with estimator.
+        /// </summary>
+        /// <param name="estimator">Survival estimator.</param>
+        public EmpiricalHazard(SurvivalEstimator estimator)
+        {
+            distribution = new EmpiricalHazardDistribution(estimator);
+        }
+        /// <summary>
+        /// Gets the survival estimator.
+        /// </summary>
+        public SurvivalEstimator Estimator => distribution.Estimator;
+        /// <summary>
+        /// Gets the times.
+        /// </summary>
+        public float[] Times => DistributionHelper.ToFloat(distribution.Times);
+        /// <summary>
+        /// Gets the hazard values.
+        /// </summary>
+        public float[] Hazards => DistributionHelper.ToFloat(distribution.Hazards);
+        /// <summary>
+        /// Gets the survival function values.
+        /// </summary>
+        public float[] Survivals => DistributionHelper.ToFloat(distribution.Survivals);
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => (float)distribution.Mean;
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => (float)distribution.Variance;
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => new[] { (float)distribution.Mode };
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => (float)distribution.Entropy;
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/GeneralContinuous.cs
+++ b/sources/Distribution/GeneralContinuous.cs
@@ -1,0 +1,110 @@
+using System;
+using Accord.Math;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines a general continuous distribution based on provided density or distribution functions.
+    /// </summary>
+    [Serializable]
+    public class GeneralContinuous : IDistribution
+    {
+        #region Private data
+        private GeneralContinuousDistribution distribution;
+        #endregion
+
+        #region GeneralContinuous components
+        /// <summary>
+        /// Initializes the distribution from a density function defined over the entire real line.
+        /// </summary>
+        /// <param name="density">Density function.</param>
+        public GeneralContinuous(Func<double, double> density)
+        {
+            distribution = GeneralContinuousDistribution.FromDensityFunction(density);
+        }
+        /// <summary>
+        /// Initializes the distribution from a density function over a support range.
+        /// </summary>
+        /// <param name="support">Support range.</param>
+        /// <param name="density">Density function.</param>
+        public GeneralContinuous(RangeFloat support, Func<double, double> density)
+        {
+            distribution = GeneralContinuousDistribution.FromDensityFunction(new DoubleRange(support.Min, support.Max), density);
+        }
+        /// <summary>
+        /// Initializes the distribution from density and distribution functions.
+        /// </summary>
+        /// <param name="support">Support range.</param>
+        /// <param name="density">Density function.</param>
+        /// <param name="distributionFunction">Cumulative distribution function.</param>
+        public GeneralContinuous(RangeFloat support, Func<double, double> density, Func<double, double> distributionFunction)
+        {
+            distribution = new GeneralContinuousDistribution(new DoubleRange(support.Min, support.Max), density, distributionFunction);
+        }
+        /// <summary>
+        /// Initializes the distribution from an existing Accord distribution.
+        /// </summary>
+        /// <param name="distribution">Accord distribution.</param>
+        public GeneralContinuous(GeneralContinuousDistribution distribution)
+        {
+            this.distribution = distribution ?? throw new ArgumentNullException(nameof(distribution));
+        }
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => (float)distribution.Mean;
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => (float)distribution.Variance;
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => new[] { (float)distribution.Mode };
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => (float)distribution.Entropy;
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/GeneralizedBeta.cs
+++ b/sources/Distribution/GeneralizedBeta.cs
@@ -1,0 +1,144 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the generalized beta distribution.
+    /// </summary>
+    [Serializable]
+    public class GeneralizedBeta : IDistribution
+    {
+        #region Private data
+        private GeneralizedBetaDistribution distribution;
+        #endregion
+
+        #region GeneralizedBeta components
+        /// <summary>
+        /// Initializes the generalized beta distribution defined on (0, 1).
+        /// </summary>
+        /// <param name="alpha">Shape parameter α.</param>
+        /// <param name="beta">Shape parameter β.</param>
+        public GeneralizedBeta(float alpha, float beta)
+        {
+            distribution = new GeneralizedBetaDistribution(alpha, beta);
+        }
+        /// <summary>
+        /// Initializes the generalized beta distribution on (min, max).
+        /// </summary>
+        /// <param name="alpha">Shape parameter α.</param>
+        /// <param name="beta">Shape parameter β.</param>
+        /// <param name="min">Minimum value.</param>
+        /// <param name="max">Maximum value.</param>
+        public GeneralizedBeta(float alpha, float beta, float min, float max)
+        {
+            distribution = new GeneralizedBetaDistribution(alpha, beta, min, max);
+        }
+        /// <summary>
+        /// Initializes the beta PERT distribution.
+        /// </summary>
+        /// <param name="min">Minimum value.</param>
+        /// <param name="max">Maximum value.</param>
+        /// <param name="mode">Most probable value.</param>
+        public GeneralizedBeta(float min, float max, float mode)
+        {
+            distribution = GeneralizedBetaDistribution.Pert(min, max, mode);
+        }
+        /// <summary>
+        /// Initializes the beta PERT distribution with scale.
+        /// </summary>
+        /// <param name="min">Minimum value.</param>
+        /// <param name="max">Maximum value.</param>
+        /// <param name="mode">Most probable value.</param>
+        /// <param name="scale">Scale (λ) parameter.</param>
+        public GeneralizedBeta(float min, float max, float mode, float scale)
+        {
+            distribution = GeneralizedBetaDistribution.Pert(min, max, mode, scale);
+        }
+        /// <summary>
+        /// Gets the shape parameter α.
+        /// </summary>
+        public float Alpha => (float)distribution.Alpha;
+        /// <summary>
+        /// Gets the shape parameter β.
+        /// </summary>
+        public float Beta => (float)distribution.Beta;
+        /// <summary>
+        /// Gets the minimum value.
+        /// </summary>
+        public float Min => (float)distribution.Min;
+        /// <summary>
+        /// Gets the maximum value.
+        /// </summary>
+        public float Max => (float)distribution.Max;
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support => new RangeFloat(Min, Max);
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => (float)distribution.Mean;
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => (float)distribution.Variance;
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => new[] { (float)distribution.Mode };
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness
+        {
+            get
+            {
+                double a = Alpha;
+                double b = Beta;
+                double numerator = 2.0 * (b - a) * Math.Sqrt(a + b + 1.0);
+                double denominator = (a + b + 2.0) * Math.Sqrt(a * b);
+                return (float)(numerator / denominator);
+            }
+        }
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess
+        {
+            get
+            {
+                double a = Alpha;
+                double b = Beta;
+                double numerator = 6.0 * ((a - b) * (a - b) * (a + b + 1.0) - a * b * (a + b + 2.0));
+                double denominator = a * b * (a + b + 2.0) * (a + b + 3.0);
+                return (float)(numerator / denominator);
+            }
+        }
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => (float)distribution.Entropy;
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/Grubb.cs
+++ b/sources/Distribution/Grubb.cs
@@ -1,0 +1,86 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the Grubb's statistic distribution.
+    /// </summary>
+    [Serializable]
+    public class Grubb : IDistribution
+    {
+        #region Private data
+        private GrubbDistribution distribution;
+        #endregion
+
+        #region Grubb components
+        /// <summary>
+        /// Initializes the Grubb's statistic distribution.
+        /// </summary>
+        /// <param name="samples">Number of samples.</param>
+        public Grubb(int samples)
+        {
+            distribution = new GrubbDistribution(samples);
+        }
+        /// <summary>
+        /// Gets the number of samples.
+        /// </summary>
+        public int Samples => distribution.NumberOfSamples;
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => throw new NotSupportedException();
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => throw new NotSupportedException();
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/KolmogorovSmirnov.cs
+++ b/sources/Distribution/KolmogorovSmirnov.cs
@@ -1,0 +1,86 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the Kolmogorov-Smirnov distribution.
+    /// </summary>
+    [Serializable]
+    public class KolmogorovSmirnov : IDistribution
+    {
+        #region Private data
+        private KolmogorovSmirnovDistribution distribution;
+        #endregion
+
+        #region KolmogorovSmirnov components
+        /// <summary>
+        /// Initializes the Kolmogorov-Smirnov distribution.
+        /// </summary>
+        /// <param name="samples">Number of samples.</param>
+        public KolmogorovSmirnov(float samples)
+        {
+            distribution = new KolmogorovSmirnovDistribution(samples);
+        }
+        /// <summary>
+        /// Gets the number of samples.
+        /// </summary>
+        public float Samples => (float)distribution.NumberOfSamples;
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => (float)distribution.Mean;
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => (float)distribution.Variance;
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => (float)distribution.Entropy;
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/MannWhitney.cs
+++ b/sources/Distribution/MannWhitney.cs
@@ -1,0 +1,128 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the Mann-Whitney U statistic distribution.
+    /// </summary>
+    [Serializable]
+    public class MannWhitney : IDistribution
+    {
+        #region Private data
+        private MannWhitneyDistribution distribution;
+        #endregion
+
+        #region MannWhitney components
+        /// <summary>
+        /// Initializes the distribution using sample sizes.
+        /// </summary>
+        /// <param name="n1">Number of observations in the first sample.</param>
+        /// <param name="n2">Number of observations in the second sample.</param>
+        public MannWhitney(int n1, int n2)
+        {
+            distribution = new MannWhitneyDistribution(n1, n2);
+        }
+        /// <summary>
+        /// Initializes the distribution from rank statistics.
+        /// </summary>
+        /// <param name="ranks">Global rank statistics.</param>
+        /// <param name="n1">Number of observations in the first sample.</param>
+        /// <param name="n2">Number of observations in the second sample.</param>
+        /// <param name="exact">Whether to compute the exact distribution.</param>
+        public MannWhitney(float[] ranks, int n1, int n2, bool? exact = null)
+        {
+            distribution = new MannWhitneyDistribution(DistributionHelper.ToDouble(ranks), n1, n2, exact);
+        }
+        /// <summary>
+        /// Initializes the distribution from rank statistics for both samples.
+        /// </summary>
+        /// <param name="ranks1">Ranks for the first sample.</param>
+        /// <param name="ranks2">Ranks for the second sample.</param>
+        /// <param name="exact">Whether to compute the exact distribution.</param>
+        public MannWhitney(float[] ranks1, float[] ranks2, bool? exact = null)
+        {
+            distribution = new MannWhitneyDistribution(DistributionHelper.ToDouble(ranks1), DistributionHelper.ToDouble(ranks2), exact);
+        }
+        /// <summary>
+        /// Gets the number of observations in the first sample.
+        /// </summary>
+        public int Samples1 => distribution.NumberOfSamples1;
+        /// <summary>
+        /// Gets the number of observations in the second sample.
+        /// </summary>
+        public int Samples2 => distribution.NumberOfSamples2;
+        /// <summary>
+        /// Gets or sets the continuity correction mode.
+        /// </summary>
+        public ContinuityCorrection Correction
+        {
+            get => distribution.Correction;
+            set => distribution.Correction = value;
+        }
+        /// <summary>
+        /// Gets whether this distribution computes exact probabilities.
+        /// </summary>
+        public bool Exact => distribution.Exact;
+        /// <summary>
+        /// Gets the statistic table used for the exact distribution.
+        /// </summary>
+        public float[] Table => DistributionHelper.ToFloat(distribution.Table);
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => (float)distribution.Mean;
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => (float)distribution.Variance;
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => new[] { (float)distribution.Mode };
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => (float)distribution.Entropy;
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/NoncentralT.cs
+++ b/sources/Distribution/NoncentralT.cs
@@ -1,0 +1,91 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the noncentral t-distribution.
+    /// </summary>
+    [Serializable]
+    public class NoncentralT : IDistribution
+    {
+        #region Private data
+        private NoncentralTDistribution distribution;
+        #endregion
+
+        #region NoncentralT components
+        /// <summary>
+        /// Initializes the noncentral t-distribution.
+        /// </summary>
+        /// <param name="degreesOfFreedom">Degrees of freedom.</param>
+        /// <param name="noncentrality">Noncentrality parameter.</param>
+        public NoncentralT(float degreesOfFreedom, float noncentrality)
+        {
+            distribution = new NoncentralTDistribution(degreesOfFreedom, noncentrality);
+        }
+        /// <summary>
+        /// Gets the degrees of freedom.
+        /// </summary>
+        public float DegreesOfFreedom => (float)distribution.DegreesOfFreedom;
+        /// <summary>
+        /// Gets the noncentrality parameter.
+        /// </summary>
+        public float Noncentrality => (float)distribution.Noncentrality;
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => (float)distribution.Mean;
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => (float)distribution.Variance;
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => new[] { (float)distribution.Mode };
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => (float)distribution.Entropy;
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/ShapiroWilk.cs
+++ b/sources/Distribution/ShapiroWilk.cs
@@ -1,0 +1,86 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the Shapiro-Wilk distribution.
+    /// </summary>
+    [Serializable]
+    public class ShapiroWilk : IDistribution
+    {
+        #region Private data
+        private ShapiroWilkDistribution distribution;
+        #endregion
+
+        #region ShapiroWilk components
+        /// <summary>
+        /// Initializes the Shapiro-Wilk distribution.
+        /// </summary>
+        /// <param name="samples">Number of samples.</param>
+        public ShapiroWilk(int samples)
+        {
+            distribution = new ShapiroWilkDistribution(samples);
+        }
+        /// <summary>
+        /// Gets the number of samples.
+        /// </summary>
+        public int Samples => distribution.NumberOfSamples;
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => (float)distribution.Mean;
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => new[] { (float)distribution.Mode };
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => throw new NotSupportedException();
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/SkewNormal.cs
+++ b/sources/Distribution/SkewNormal.cs
@@ -1,0 +1,147 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the skew normal distribution.
+    /// </summary>
+    /// <remarks>
+    /// More information can be found on the website:
+    /// https://en.wikipedia.org/wiki/Skew_normal_distribution
+    /// </remarks>
+    [Serializable]
+    public class SkewNormal : IDistribution
+    {
+        #region Private data
+        private SkewNormalDistribution distribution;
+        #endregion
+
+        #region SkewNormal components
+        /// <summary>
+        /// Initializes the skew normal distribution.
+        /// </summary>
+        public SkewNormal()
+        {
+            distribution = new SkewNormalDistribution();
+        }
+        /// <summary>
+        /// Initializes the skew normal distribution.
+        /// </summary>
+        /// <param name="location">Location parameter.</param>
+        public SkewNormal(float location)
+        {
+            distribution = new SkewNormalDistribution(location);
+        }
+        /// <summary>
+        /// Initializes the skew normal distribution.
+        /// </summary>
+        /// <param name="location">Location parameter.</param>
+        /// <param name="scale">Scale parameter (greater than zero).</param>
+        public SkewNormal(float location, float scale)
+        {
+            distribution = new SkewNormalDistribution(location, scale);
+        }
+        /// <summary>
+        /// Initializes the skew normal distribution.
+        /// </summary>
+        /// <param name="location">Location parameter.</param>
+        /// <param name="scale">Scale parameter (greater than zero).</param>
+        /// <param name="shape">Shape parameter.</param>
+        public SkewNormal(float location, float scale, float shape)
+        {
+            distribution = new SkewNormalDistribution(location, scale, shape);
+        }
+        /// <summary>
+        /// Gets or sets the location parameter.
+        /// </summary>
+        public float Location
+        {
+            get => (float)distribution.Location;
+            set => distribution = new SkewNormalDistribution(value, Scale, Shape);
+        }
+        /// <summary>
+        /// Gets or sets the scale parameter.
+        /// </summary>
+        public float Scale
+        {
+            get => (float)distribution.Scale;
+            set => distribution = new SkewNormalDistribution(Location, value, Shape);
+        }
+        /// <summary>
+        /// Gets or sets the shape parameter.
+        /// </summary>
+        public float Shape
+        {
+            get => (float)distribution.Shape;
+            set => distribution = new SkewNormalDistribution(Location, Scale, value);
+        }
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => (float)distribution.Mean;
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => (float)distribution.Variance;
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => new[] { (float)distribution.Mode };
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => (float)distribution.Skewness;
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess
+        {
+            get
+            {
+                double alpha = Shape;
+                double delta = alpha / Math.Sqrt(1.0 + alpha * alpha);
+                double b = delta * Math.Sqrt(2.0 / Math.PI);
+                double c = 1.0 - 2.0 * delta * delta / Math.PI;
+                double excess = 2.0 * (Math.PI - 3.0) * b * b * b * b / (c * c);
+                return (float)excess;
+            }
+        }
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => (float)distribution.Entropy;
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/VonMises.cs
+++ b/sources/Distribution/VonMises.cs
@@ -1,0 +1,102 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the von-Mises (circular normal) distribution.
+    /// </summary>
+    [Serializable]
+    public class VonMises : IDistribution
+    {
+        #region Private data
+        private VonMisesDistribution distribution;
+        #endregion
+
+        #region VonMises components
+        /// <summary>
+        /// Initializes the von-Mises distribution with zero mean and unit concentration.
+        /// </summary>
+        public VonMises()
+        {
+            distribution = new VonMisesDistribution();
+        }
+        /// <summary>
+        /// Initializes the von-Mises distribution with zero mean.
+        /// </summary>
+        /// <param name="concentration">Concentration parameter κ.</param>
+        public VonMises(float concentration)
+        {
+            distribution = new VonMisesDistribution(concentration);
+        }
+        /// <summary>
+        /// Initializes the von-Mises distribution.
+        /// </summary>
+        /// <param name="mean">Mean angle μ.</param>
+        /// <param name="concentration">Concentration parameter κ.</param>
+        public VonMises(float mean, float concentration)
+        {
+            distribution = new VonMisesDistribution(mean, concentration);
+        }
+        /// <summary>
+        /// Gets the mean value μ.
+        /// </summary>
+        public float Mean => (float)distribution.Mean;
+        /// <summary>
+        /// Gets the median value μ.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode value μ.
+        /// </summary>
+        public float[] Mode => new[] { (float)distribution.Mode };
+        /// <summary>
+        /// Gets the concentration parameter κ.
+        /// </summary>
+        public float Concentration => (float)distribution.Concentration;
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => (float)distribution.Variance;
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => (float)distribution.Entropy;
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/Distribution/Wilcoxon.cs
+++ b/sources/Distribution/Wilcoxon.cs
@@ -1,0 +1,111 @@
+using System;
+using Accord.Statistics.Distributions.Univariate;
+using UMapx.Core;
+
+namespace UMapx.Distribution
+{
+    /// <summary>
+    /// Defines the Wilcoxon signed-rank distribution.
+    /// </summary>
+    [Serializable]
+    public class Wilcoxon : IDistribution
+    {
+        #region Private data
+        private WilcoxonDistribution distribution;
+        #endregion
+
+        #region Wilcoxon components
+        /// <summary>
+        /// Initializes the Wilcoxon distribution using the number of observations.
+        /// </summary>
+        /// <param name="samples">Number of observations.</param>
+        public Wilcoxon(int samples)
+        {
+            distribution = new WilcoxonDistribution(samples);
+        }
+        /// <summary>
+        /// Initializes the Wilcoxon distribution from rank statistics.
+        /// </summary>
+        /// <param name="ranks">Rank statistics.</param>
+        /// <param name="exact">Whether to compute the exact distribution.</param>
+        public Wilcoxon(float[] ranks, bool? exact = null)
+        {
+            distribution = new WilcoxonDistribution(DistributionHelper.ToDouble(ranks), exact);
+        }
+        /// <summary>
+        /// Gets the number of effective samples.
+        /// </summary>
+        public int Samples => distribution.NumberOfSamples;
+        /// <summary>
+        /// Gets whether the distribution computes exact probabilities.
+        /// </summary>
+        public bool Exact => distribution.Exact;
+        /// <summary>
+        /// Gets or sets the continuity correction.
+        /// </summary>
+        public ContinuityCorrection Correction
+        {
+            get => distribution.Correction;
+            set => distribution.Correction = value;
+        }
+        /// <summary>
+        /// Gets the statistic table for the exact distribution.
+        /// </summary>
+        public float[] Table => DistributionHelper.ToFloat(distribution.Table);
+        /// <summary>
+        /// Gets the support interval of the argument.
+        /// </summary>
+        public RangeFloat Support
+        {
+            get
+            {
+                var support = distribution.Support;
+                return new RangeFloat((float)support.Min, (float)support.Max);
+            }
+        }
+        /// <summary>
+        /// Gets the mean value.
+        /// </summary>
+        public float Mean => (float)distribution.Mean;
+        /// <summary>
+        /// Gets the variance value.
+        /// </summary>
+        public float Variance => (float)distribution.Variance;
+        /// <summary>
+        /// Gets the median value.
+        /// </summary>
+        public float Median => (float)distribution.Median;
+        /// <summary>
+        /// Gets the mode values.
+        /// </summary>
+        public float[] Mode => new[] { (float)distribution.Mode };
+        /// <summary>
+        /// Gets the value of the asymmetry coefficient.
+        /// </summary>
+        public float Skewness => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the excess kurtosis (kurtosis minus 3).
+        /// </summary>
+        /// <remarks>
+        /// Full kurtosis equals 3 plus this value.
+        /// </remarks>
+        public float Excess => throw new NotSupportedException();
+        /// <summary>
+        /// Gets the value of differential entropy.
+        /// </summary>
+        public float Entropy => (float)distribution.Entropy;
+        /// <summary>
+        /// Returns the value of the probability density function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Function(float x) => (float)distribution.ProbabilityDensityFunction(x);
+        /// <summary>
+        /// Returns the value of the probability distribution function.
+        /// </summary>
+        /// <param name="x">Value</param>
+        /// <returns>Value</returns>
+        public float Distribution(float x) => (float)distribution.DistributionFunction(x);
+        #endregion
+    }
+}

--- a/sources/UMapx.csproj
+++ b/sources/UMapx.csproj
@@ -56,6 +56,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Drawing.Common" Version="8.0.1" />
+    <PackageReference Include="Accord.Statistics" Version="3.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add wrappers for continuous distributions missing from UMapx by composing the corresponding Accord implementations (Anderson-Darling, Empirical, EmpiricalHazard, GeneralContinuous, GeneralizedBeta, Grubb, Kolmogorov-Smirnov, Mann-Whitney, NoncentralT, Shapiro-Wilk, SkewNormal, VonMises, Wilcoxon)
- add a helper for array conversions and reference Accord.Statistics so the wrappers can delegate to the existing Accord code

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68c94644ba008321bec43f6f68d35199