### PR TITLE
Fix power normal and lognormal formulas

### DIFF
--- a/sources/Distribution/PowerLognormal.cs
+++ b/sources/Distribution/PowerLognormal.cs
@@ -124,7 +124,8 @@ namespace UMapx.Distribution
 
         #region Methods
         /// <summary>
-        /// Returns the value of the probability density function.
+        /// Returns the value of the probability density function f(x) = power · φ(z) · Φ(z)^(power - 1) / (x · sigma).
+        /// Here z = ln(x) / sigma.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>
@@ -137,19 +138,20 @@ namespace UMapx.Distribution
 
             double z = Math.Log(x) / sigma;
             double pdf = StandardNormalPdf(z);
-            double cdf = StandardNormalCdf(-z);
+            double cdf = StandardNormalCdf(z);
 
-            if (cdf <= 0)
+            if (cdf <= double.Epsilon)
             {
                 return 0f;
             }
 
+            cdf = Math.Min(cdf, 1.0);
             double factor = power / (x * sigma);
             double value = factor * pdf * Math.Pow(cdf, power - 1.0);
             return (float)value;
         }
         /// <summary>
-        /// Returns the value of the cumulative distribution function.
+        /// Returns the value of the cumulative distribution function F(x) = Φ(z)^power, where z = ln(x) / sigma.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>
@@ -161,8 +163,19 @@ namespace UMapx.Distribution
             }
 
             double z = Math.Log(x) / sigma;
-            double cdf = StandardNormalCdf(-z);
-            double result = 1.0 - Math.Pow(cdf, power);
+            double cdf = StandardNormalCdf(z);
+
+            if (cdf <= 0.0)
+            {
+                return 0f;
+            }
+
+            if (cdf >= 1.0)
+            {
+                return 1f;
+            }
+
+            double result = Math.Pow(cdf, power);
             return (float)result;
         }
         #endregion

--- a/sources/Distribution/PowerNormal.cs
+++ b/sources/Distribution/PowerNormal.cs
@@ -105,32 +105,44 @@ namespace UMapx.Distribution
 
         #region Methods
         /// <summary>
-        /// Returns the value of the probability density function.
+        /// Returns the value of the probability density function f(x) = power · φ(x) · Φ(x)^(power - 1).
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>
         public float Function(float x)
         {
             double pdf = StandardNormalPdf(x);
-            double cdf = StandardNormalCdf(-x);
+            double cdf = StandardNormalCdf(x);
 
-            if (cdf <= 0)
+            if (cdf <= double.Epsilon)
             {
                 return 0f;
             }
 
+            cdf = Math.Min(cdf, 1.0);
             double value = power * pdf * Math.Pow(cdf, power - 1.0);
             return (float)value;
         }
         /// <summary>
-        /// Returns the value of the cumulative distribution function.
+        /// Returns the value of the cumulative distribution function F(x) = Φ(x)^power.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>
         public float Distribution(float x)
         {
-            double cdf = StandardNormalCdf(-x);
-            double result = 1.0 - Math.Pow(cdf, power);
+            double cdf = StandardNormalCdf(x);
+
+            if (cdf <= 0.0)
+            {
+                return 0f;
+            }
+
+            if (cdf >= 1.0)
+            {
+                return 1f;
+            }
+
+            double result = Math.Pow(cdf, power);
             return (float)result;
         }
         #endregion


### PR DESCRIPTION
## Summary
- update the power normal PDF and CDF to use the standard normal CDF directly
- align the power lognormal PDF and CDF with the corrected standard normal usage and document the formulas

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f49bc9488321abf87afd923b8180