### PR TITLE
Fix B parameter validation message

### DIFF
--- a/sources/Distribution/UQuadratic.cs
+++ b/sources/Distribution/UQuadratic.cs
@@ -70,7 +70,7 @@ namespace UMapx.Distribution
             set
             {
                 if (value <= a)
-                    throw new ArgumentException("The value of parameter b must be either greater than or equal to a");
+                    throw new ArgumentException("The value of parameter b must be greater than a");
 
                 this.b = value;
                 UpdateCoefficients();


### PR DESCRIPTION
## Summary
- update the validation message for the B parameter to match the strict greater-than requirement

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc10d010d08321bd7e413c8863ec97