### PR TITLE
Fix Distribution XML comments for cumulative functions

### DIFF
--- a/sources/Distribution/Arcsine.cs
+++ b/sources/Distribution/Arcsine.cs
@@ -78,7 +78,7 @@ namespace UMapx.Distribution
             get { return Maths.Log(Maths.Pi / 4); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Bernoulli.cs
+++ b/sources/Distribution/Bernoulli.cs
@@ -167,7 +167,7 @@ namespace UMapx.Distribution
             return 0;
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the probability mass cumulative function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/BetaPrime.cs
+++ b/sources/Distribution/BetaPrime.cs
@@ -176,7 +176,7 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Binomial.cs
+++ b/sources/Distribution/Binomial.cs
@@ -206,7 +206,7 @@ namespace UMapx.Distribution
             return Maths.Exp(log);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the probability mass cumulative function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/BirnbaumSaunders.cs
+++ b/sources/Distribution/BirnbaumSaunders.cs
@@ -210,7 +210,7 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Burr.cs
+++ b/sources/Distribution/Burr.cs
@@ -205,7 +205,7 @@ namespace UMapx.Distribution
             get { return new RangeFloat(0, float.PositiveInfinity); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Cauchy.cs
+++ b/sources/Distribution/Cauchy.cs
@@ -135,7 +135,7 @@ namespace UMapx.Distribution
             return 1.0f / (Maths.Pi * g * (1.0f + Maths.Pow((x - x0) / g)));
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/ChiSquare.cs
+++ b/sources/Distribution/ChiSquare.cs
@@ -139,7 +139,7 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Erlang.cs
+++ b/sources/Distribution/Erlang.cs
@@ -160,7 +160,7 @@ namespace UMapx.Distribution
             return Maths.Pow(lambda, k) * Maths.Pow(x, k - 1) * Maths.Exp(-lambda * x) / (float)Special.Factorial(k - 1);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Exponential.cs
+++ b/sources/Distribution/Exponential.cs
@@ -134,7 +134,7 @@ namespace UMapx.Distribution
             return l * Maths.Exp(-l * x);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/FisherSnedecor.cs
+++ b/sources/Distribution/FisherSnedecor.cs
@@ -191,7 +191,7 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/FisherZ.cs
+++ b/sources/Distribution/FisherZ.cs
@@ -171,7 +171,7 @@ namespace UMapx.Distribution
             get { return new RangeFloat(float.NegativeInfinity, float.PositiveInfinity); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <remarks>
         /// The CDF is expressed through the regularized incomplete beta function

--- a/sources/Distribution/FoldedNormal.cs
+++ b/sources/Distribution/FoldedNormal.cs
@@ -137,7 +137,7 @@ namespace UMapx.Distribution
             return (float)((StandardNormalPdf(a) + StandardNormalPdf(b)) / sigma);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Gamma.cs
+++ b/sources/Distribution/Gamma.cs
@@ -161,7 +161,7 @@ namespace UMapx.Distribution
             return Maths.Pow(x, k - 1) * Maths.Exp(-x / thetta) / (Special.Gamma(k) * Maths.Pow(thetta, k));
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Gaussian.cs
+++ b/sources/Distribution/Gaussian.cs
@@ -147,7 +147,7 @@ namespace UMapx.Distribution
             return Maths.Exp(Maths.Pow(x - mu, 2) / (-2.0f * sigma * sigma)) / (Maths.Sqrt(2.0f * Maths.Pi) * sigma);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/GeneralizedNormal.cs
+++ b/sources/Distribution/GeneralizedNormal.cs
@@ -147,7 +147,7 @@ namespace UMapx.Distribution
             return norm * Maths.Exp(-Maths.Pow(z, beta));
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Geometric.cs
+++ b/sources/Distribution/Geometric.cs
@@ -144,7 +144,7 @@ namespace UMapx.Distribution
             return Maths.Pow(q, k) * p;
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the probability mass cumulative function.
         /// </summary>
         /// <param name="x">Number of failures before the first success</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Gompertz.cs
+++ b/sources/Distribution/Gompertz.cs
@@ -144,7 +144,7 @@ namespace UMapx.Distribution
             get { return new RangeFloat(0, float.PositiveInfinity); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Gumbel.cs
+++ b/sources/Distribution/Gumbel.cs
@@ -137,7 +137,7 @@ namespace UMapx.Distribution
             get { return Maths.Log(beta) + Maths.Gamma + 1; }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/HyperbolicSecant.cs
+++ b/sources/Distribution/HyperbolicSecant.cs
@@ -81,7 +81,7 @@ namespace UMapx.Distribution
             get { return Maths.Log(4f); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Hypergeometric.cs
+++ b/sources/Distribution/Hypergeometric.cs
@@ -247,7 +247,7 @@ namespace UMapx.Distribution
             return (float)(a * b / c);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the probability mass cumulative function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/InverseChiSquare.cs
+++ b/sources/Distribution/InverseChiSquare.cs
@@ -130,7 +130,7 @@ namespace UMapx.Distribution
             return (a * b * c) / d;
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/InverseGamma.cs
+++ b/sources/Distribution/InverseGamma.cs
@@ -163,7 +163,7 @@ namespace UMapx.Distribution
             return constant * Maths.Pow(x, -alpha - 1f) * Maths.Exp(-beta / x);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/InverseGaussian.cs
+++ b/sources/Distribution/InverseGaussian.cs
@@ -134,7 +134,7 @@ namespace UMapx.Distribution
             return (float)(coef * Math.Exp(expo));
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Kumaraswamy.cs
+++ b/sources/Distribution/Kumaraswamy.cs
@@ -176,7 +176,7 @@ namespace UMapx.Distribution
             get { return new RangeFloat(0, 1); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Laplace.cs
+++ b/sources/Distribution/Laplace.cs
@@ -147,7 +147,7 @@ namespace UMapx.Distribution
             return a / 2.0f * Maths.Exp(-a * Maths.Abs(x - b));
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Levy.cs
+++ b/sources/Distribution/Levy.cs
@@ -134,7 +134,7 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/LogGaussian.cs
+++ b/sources/Distribution/LogGaussian.cs
@@ -151,7 +151,7 @@ namespace UMapx.Distribution
             return Maths.Exp(Maths.Pow((Maths.Log(x) - mu), 2) / (-2.0f * sigma * sigma)) / (Maths.Sqrt(2.0f * Maths.Pi) * sigma * x);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/LogLogistic.cs
+++ b/sources/Distribution/LogLogistic.cs
@@ -143,7 +143,7 @@ namespace UMapx.Distribution
             return (b / a) * Maths.Pow(x / a, b - 1) / Maths.Pow(1.0f + Maths.Pow(x / a, b), 2);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Logarithmic.cs
+++ b/sources/Distribution/Logarithmic.cs
@@ -107,7 +107,7 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the probability mass cumulative function.
         /// </summary>
         /// <param name="x">Value (x ≥ 1)</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Logistic.cs
+++ b/sources/Distribution/Logistic.cs
@@ -141,7 +141,7 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Nakagami.cs
+++ b/sources/Distribution/Nakagami.cs
@@ -173,7 +173,7 @@ namespace UMapx.Distribution
             get { throw new NotSupportedException(); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Pareto.cs
+++ b/sources/Distribution/Pareto.cs
@@ -181,7 +181,7 @@ namespace UMapx.Distribution
             return k * Maths.Pow(xm, k) / Maths.Pow(x, k + 1);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Poisson.cs
+++ b/sources/Distribution/Poisson.cs
@@ -144,7 +144,7 @@ namespace UMapx.Distribution
             return Maths.Exp(-l) * Maths.Pow(l, k) / (float)Special.Factorial(k);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the probability mass cumulative function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Rademacher.cs
+++ b/sources/Distribution/Rademacher.cs
@@ -83,7 +83,7 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the probability mass cumulative function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Rayleigh.cs
+++ b/sources/Distribution/Rayleigh.cs
@@ -136,7 +136,7 @@ namespace UMapx.Distribution
             return x / sigma / sigma * Maths.Exp(-(x * x) / (2 * sigma * sigma));
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Student.cs
+++ b/sources/Distribution/Student.cs
@@ -147,7 +147,7 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Triangular.cs
+++ b/sources/Distribution/Triangular.cs
@@ -169,7 +169,7 @@ namespace UMapx.Distribution
             }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/UQuadratic.cs
+++ b/sources/Distribution/UQuadratic.cs
@@ -145,7 +145,7 @@ namespace UMapx.Distribution
             get { return new RangeFloat(a, b); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Uniform.cs
+++ b/sources/Distribution/Uniform.cs
@@ -152,7 +152,7 @@ namespace UMapx.Distribution
             return 1.0f / (b - a);
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Weibull.cs
+++ b/sources/Distribution/Weibull.cs
@@ -154,7 +154,7 @@ namespace UMapx.Distribution
             return (k / l) * Maths.Pow(x / l, k - 1) * Maths.Exp(-Maths.Pow(x / l, k));
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/Wigner.cs
+++ b/sources/Distribution/Wigner.cs
@@ -131,7 +131,7 @@ namespace UMapx.Distribution
             return b * a;
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>

--- a/sources/Distribution/WrappedCauchy.cs
+++ b/sources/Distribution/WrappedCauchy.cs
@@ -121,7 +121,7 @@ namespace UMapx.Distribution
             get { return Maths.Log(2 * Maths.Pi * (1 - Maths.Exp(-2 * gamma))); }
         }
         /// <summary>
-        /// Returns the value of the probability distribution function.
+        /// Returns the value of the cumulative distribution function.
         /// </summary>
         /// <param name="x">Value</param>
         /// <returns>Value</returns>


### PR DESCRIPTION
## Summary
- update the `Distribution` method XML documentation across continuous distribution classes to describe the cumulative distribution function
- adjust the XML comments for discrete distributions to refer to the probability mass cumulative function

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc10c54ae48321990ff014da4c84cf