### PR TITLE
Add GSVD decomposition for real matrices

### DIFF
--- a/sources/Decomposition/GSVD.cs
+++ b/sources/Decomposition/GSVD.cs
@@ -1,0 +1,253 @@
+using System;
+using UMapx.Core;
+
+namespace UMapx.Decomposition
+{
+    /// <summary>
+    /// Defines generalized singular value decomposition for a pair of real matrices.
+    /// </summary>
+    /// <remarks>
+    /// Finds orthogonal matrices U and V, and a nonsingular matrix Q such that
+    /// Uᵀ * A * Q = diag(C) and Vᵀ * B * Q = diag(S) with non-negative diagonals
+    /// satisfying Cᵀ * C + Sᵀ * S = I. Only single precision (float) arithmetic is supported.
+    /// </remarks>
+    [Serializable]
+    public class GSVD
+    {
+        #region Private data
+        private readonly int m;
+        private readonly int p;
+        private readonly int n;
+        private readonly float[,] u;
+        private readonly float[,] v;
+        private readonly float[,] q;
+        private readonly float[] c;
+        private readonly float[] s;
+        private readonly float eps;
+        #endregion
+
+        #region Initialize
+        /// <summary>
+        /// Initializes generalized singular value decomposition.
+        /// </summary>
+        /// <param name="A">Matrix A (m × n)</param>
+        /// <param name="B">Matrix B (p × n)</param>
+        /// <param name="eps">Tolerance used when detecting rank deficiencies</param>
+        public GSVD(float[,] A, float[,] B, float eps = 1e-6f)
+        {
+            if (A == null || B == null)
+                throw new ArgumentNullException(A == null ? nameof(A) : nameof(B));
+
+            if (A.GetLength(1) != B.GetLength(1))
+                throw new ArgumentException("Matrices must have the same number of columns");
+
+            this.m = A.GetLength(0);
+            this.p = B.GetLength(0);
+            this.n = A.GetLength(1);
+            this.eps = (eps < 0) ? 0f : eps;
+
+            // Form the symmetric positive definite matrix C = AᵀA + BᵀB.
+            float[,] ata = Matrice.Dot(A.Transpose(), A);
+            float[,] btb = Matrice.Dot(B.Transpose(), B);
+            float[,] cMat = ata.Add(btb);
+
+            // Cholesky factorization of C.
+            var chol = new Cholesky(cMat);
+            float[,] l = chol.L;
+            float[,] lInv = l.Invert();
+            float[,] lInvT = lInv.Transpose();
+
+            // Reduce the generalized eigenvalue problem to a standard symmetric eigenproblem.
+            float[,] tmp = Matrice.Dot(ata, lInv);
+            float[,] sym = Symmetrize(Matrice.Dot(lInvT, tmp));
+
+            // Solve the symmetric eigenproblem.
+            var evd = new EVD(sym, this.eps);
+            float[,] eigenvectors = evd.V;
+            Complex32[] eigenvalues = evd.D;
+
+            this.u = new float[m, n];
+            this.v = new float[p, n];
+            this.q = new float[n, n];
+            this.c = new float[n];
+            this.s = new float[n];
+
+            int[] order = new int[n];
+            for (int i = 0; i < n; i++)
+            {
+                order[i] = i;
+            }
+            float[] eigenReal = new float[n];
+            for (int i = 0; i < n; i++)
+            {
+                eigenReal[i] = eigenvalues[i].Real;
+            }
+            Array.Sort(order, (a, b) => eigenReal[b].CompareTo(eigenReal[a]));
+
+            for (int idx = 0; idx < n; idx++)
+            {
+                int k = order[idx];
+                Complex32 lambda = eigenvalues[k];
+                if (Math.Abs(lambda.Imag) > 1e-3f)
+                    throw new InvalidOperationException("Generalized singular values are complex");
+
+                float[] y = eigenvectors.GetCol(k);
+                float[] qVec = Multiply(lInv, y);
+
+                float[] cTimesQ = Multiply(cMat, qVec);
+                float normC = Maths.Sqrt(Math.Max(qVec.Dot(cTimesQ), 0f));
+                if (normC < this.eps)
+                    throw new InvalidOperationException("Failed to normalize GSVD basis vector");
+
+                float invNormC = 1f / normC;
+                float[] qNormalized = Scale(qVec, invNormC);
+                SetColumn(this.q, idx, qNormalized);
+
+                float[] aCol = Multiply(A, qNormalized);
+                float[] bCol = Multiply(B, qNormalized);
+
+                float cVal = Matrice.Norm(aCol);
+                float sVal = Matrice.Norm(bCol);
+
+                if (cVal <= this.eps) cVal = 0f;
+                if (sVal <= this.eps) sVal = 0f;
+
+                this.c[idx] = cVal;
+                this.s[idx] = sVal;
+
+                float[] uCol = (cVal > this.eps) ? Scale(aCol, 1f / cVal) : CreateOrthonormalVector(m, this.u, idx, this.eps);
+                float[] vCol = (sVal > this.eps) ? Scale(bCol, 1f / sVal) : CreateOrthonormalVector(p, this.v, idx, this.eps);
+
+                SetColumn(this.u, idx, uCol);
+                SetColumn(this.v, idx, vCol);
+            }
+        }
+        #endregion
+
+        #region Standard voids
+        /// <summary>
+        /// Gets the left orthogonal factor U (m × n with orthonormal columns).
+        /// </summary>
+        public float[,] U => u;
+        /// <summary>
+        /// Gets the right orthogonal factor V (p × n with orthonormal columns).
+        /// </summary>
+        public float[,] V => v;
+        /// <summary>
+        /// Gets the nonsingular transformation matrix Q.
+        /// </summary>
+        public float[,] Q => q;
+        /// <summary>
+        /// Gets the generalized cosines (diagonal of C).
+        /// </summary>
+        public float[] C => c;
+        /// <summary>
+        /// Gets the generalized sines (diagonal of S).
+        /// </summary>
+        public float[] S => s;
+        #endregion
+
+        #region Private voids
+        private static float[,] Symmetrize(float[,] matrix)
+        {
+            int n = matrix.GetLength(0);
+            float[,] result = new float[n, n];
+            for (int i = 0; i < n; i++)
+            {
+                for (int j = i; j < n; j++)
+                {
+                    float value = 0.5f * (matrix[i, j] + matrix[j, i]);
+                    result[i, j] = value;
+                    result[j, i] = value;
+                }
+            }
+            return result;
+        }
+
+        private static float[] Multiply(float[,] matrix, float[] vector)
+        {
+            int rows = matrix.GetLength(0);
+            int cols = matrix.GetLength(1);
+            float[] result = new float[rows];
+            for (int i = 0; i < rows; i++)
+            {
+                float sum = 0f;
+                for (int j = 0; j < cols; j++)
+                {
+                    sum += matrix[i, j] * vector[j];
+                }
+                result[i] = sum;
+            }
+            return result;
+        }
+
+        private static float[] Scale(float[] vector, float scale)
+        {
+            float[] result = new float[vector.Length];
+            for (int i = 0; i < vector.Length; i++)
+            {
+                result[i] = vector[i] * scale;
+            }
+            return result;
+        }
+
+        private static void SetColumn(float[,] matrix, int column, float[] data)
+        {
+            int rows = matrix.GetLength(0);
+            for (int i = 0; i < rows; i++)
+            {
+                matrix[i, column] = (i < data.Length) ? data[i] : 0f;
+            }
+        }
+
+        private static float[] CreateOrthonormalVector(int size, float[,] existing, int count, float eps)
+        {
+            float[] candidate = new float[size];
+            for (int attempt = 0; attempt < size; attempt++)
+            {
+                for (int i = 0; i < size; i++)
+                    candidate[i] = 0f;
+                candidate[attempt] = 1f;
+
+                for (int j = 0; j < count; j++)
+                {
+                    float[] prev = existing.GetCol(j);
+                    float proj = prev.Dot(candidate);
+                    for (int i = 0; i < size; i++)
+                        candidate[i] -= proj * prev[i];
+                }
+
+                float norm = candidate.Norm();
+                if (norm > eps)
+                {
+                    for (int i = 0; i < size; i++)
+                        candidate[i] /= norm;
+                    return candidate;
+                }
+            }
+
+            for (int i = 0; i < size; i++)
+                candidate[i] = 0f;
+            candidate[0] = 1f;
+
+            for (int j = 0; j < count; j++)
+            {
+                float[] prev = existing.GetCol(j);
+                float proj = prev.Dot(candidate);
+                for (int i = 0; i < size; i++)
+                    candidate[i] -= proj * prev[i];
+            }
+
+            float fallbackNorm = candidate.Norm();
+            if (fallbackNorm > 0f)
+            {
+                for (int i = 0; i < size; i++)
+                    candidate[i] /= fallbackNorm;
+            }
+
+            return candidate;
+        }
+
+        #endregion
+    }
+}

--- a/sources/Decomposition/GSVD.cs
+++ b/sources/Decomposition/GSVD.cs
@@ -33,7 +33,7 @@ namespace UMapx.Decomposition
         /// <param name="A">Matrix A (m × n)</param>
         /// <param name="B">Matrix B (p × n)</param>
         /// <param name="eps">Tolerance used when detecting rank deficiencies</param>
-        public GSVD(float[,] A, float[,] B, float eps = 1e-6f)
+        public GSVD(float[,] A, float[,] B, float eps = 1e-8f)
         {
             if (A == null || B == null)
                 throw new ArgumentNullException(A == null ? nameof(A) : nameof(B));

--- a/sources/Decomposition/GSVD.cs
+++ b/sources/Decomposition/GSVD.cs
@@ -4,250 +4,379 @@ using UMapx.Core;
 namespace UMapx.Decomposition
 {
     /// <summary>
-    /// Defines generalized singular value decomposition for a pair of real matrices.
+    /// Generalized SVD (thin GSVD) for a pair of matrices A (m×n), B (p×n).
+    /// Returns orthonormal U (m×n), V (p×n), invertible Q (n×n),
+    /// and vectors C[i] = ||A q_i||, S[i] = ||B q_i|| with C[i]^2 + S[i]^2 = 1.
     /// </summary>
-    /// <remarks>
-    /// Finds orthogonal matrices U and V, and a nonsingular matrix Q such that
-    /// Uᵀ * A * Q = diag(C) and Vᵀ * B * Q = diag(S) with non-negative diagonals
-    /// satisfying Cᵀ * C + Sᵀ * S = I. Only single precision (float) arithmetic is supported.
-    /// </remarks>
     [Serializable]
     public class GSVD
     {
         #region Private data
-        private readonly int m;
-        private readonly int p;
-        private readonly int n;
-        private readonly float[,] u;
-        private readonly float[,] v;
-        private readonly float[,] q;
-        private readonly float[] c;
-        private readonly float[] s;
+        private readonly int m, p, n;
         private readonly float eps;
+
+        // thin factors:
+        private readonly float[,] u; // m×n, columns orthonormal
+        private readonly float[,] v; // p×n, columns orthonormal
+        private readonly float[,] q; // n×n, invertible
+        private readonly float[] c;  // length n, c_i = ||A q_i||
+        private readonly float[] s;  // length n, s_i = ||B q_i||
         #endregion
 
-        #region Initialize
+        #region Public API
         /// <summary>
-        /// Initializes generalized singular value decomposition.
-        /// </summary>
-        /// <param name="A">Matrix A (m × n)</param>
-        /// <param name="B">Matrix B (p × n)</param>
-        /// <param name="eps">Tolerance used when detecting rank deficiencies</param>
-        public GSVD(float[,] A, float[,] B, float eps = 1e-8f)
-        {
-            if (A == null || B == null)
-                throw new ArgumentNullException(A == null ? nameof(A) : nameof(B));
-
-            if (A.GetLength(1) != B.GetLength(1))
-                throw new ArgumentException("Matrices must have the same number of columns");
-
-            this.m = A.GetLength(0);
-            this.p = B.GetLength(0);
-            this.n = A.GetLength(1);
-            this.eps = (eps < 0) ? 0f : eps;
-
-            // Form the symmetric positive definite matrix C = AᵀA + BᵀB.
-            float[,] ata = Matrice.Dot(A.Transpose(), A);
-            float[,] btb = Matrice.Dot(B.Transpose(), B);
-            float[,] cMat = ata.Add(btb);
-
-            // Cholesky factorization of C.
-            var chol = new Cholesky(cMat);
-            float[,] l = chol.L;
-            float[,] lInv = l.Invert();
-            float[,] lInvT = lInv.Transpose();
-
-            // Reduce the generalized eigenvalue problem to a standard symmetric eigenproblem.
-            float[,] tmp = Matrice.Dot(ata, lInv);
-            float[,] sym = Symmetrize(Matrice.Dot(lInvT, tmp));
-
-            // Solve the symmetric eigenproblem.
-            var evd = new EVD(sym, this.eps);
-            float[,] eigenvectors = evd.V;
-            Complex32[] eigenvalues = evd.D;
-
-            this.u = new float[m, n];
-            this.v = new float[p, n];
-            this.q = new float[n, n];
-            this.c = new float[n];
-            this.s = new float[n];
-
-            int[] order = new int[n];
-            for (int i = 0; i < n; i++)
-            {
-                order[i] = i;
-            }
-            float[] eigenReal = new float[n];
-            for (int i = 0; i < n; i++)
-            {
-                eigenReal[i] = eigenvalues[i].Real;
-            }
-            Array.Sort(order, (a, b) => eigenReal[b].CompareTo(eigenReal[a]));
-
-            for (int idx = 0; idx < n; idx++)
-            {
-                int k = order[idx];
-                Complex32 lambda = eigenvalues[k];
-                if (Math.Abs(lambda.Imag) > 1e-3f)
-                    throw new InvalidOperationException("Generalized singular values are complex");
-
-                float[] y = eigenvectors.GetCol(k);
-                float[] qVec = Multiply(lInv, y);
-
-                float[] cTimesQ = Multiply(cMat, qVec);
-                float normC = Maths.Sqrt(Math.Max(qVec.Dot(cTimesQ), 0f));
-                if (normC < this.eps)
-                    throw new InvalidOperationException("Failed to normalize GSVD basis vector");
-
-                float invNormC = 1f / normC;
-                float[] qNormalized = Scale(qVec, invNormC);
-                SetColumn(this.q, idx, qNormalized);
-
-                float[] aCol = Multiply(A, qNormalized);
-                float[] bCol = Multiply(B, qNormalized);
-
-                float cVal = Matrice.Norm(aCol);
-                float sVal = Matrice.Norm(bCol);
-
-                if (cVal <= this.eps) cVal = 0f;
-                if (sVal <= this.eps) sVal = 0f;
-
-                this.c[idx] = cVal;
-                this.s[idx] = sVal;
-
-                float[] uCol = (cVal > this.eps) ? Scale(aCol, 1f / cVal) : CreateOrthonormalVector(m, this.u, idx, this.eps);
-                float[] vCol = (sVal > this.eps) ? Scale(bCol, 1f / sVal) : CreateOrthonormalVector(p, this.v, idx, this.eps);
-
-                SetColumn(this.u, idx, uCol);
-                SetColumn(this.v, idx, vCol);
-            }
-        }
-        #endregion
-
-        #region Standard voids
-        /// <summary>
-        /// Gets the left orthogonal factor U (m × n with orthonormal columns).
+        /// Left factor with orthonormal columns (m×n).
         /// </summary>
         public float[,] U => u;
+
         /// <summary>
-        /// Gets the right orthogonal factor V (p × n with orthonormal columns).
+        /// Right factor with orthonormal columns (p×n).
         /// </summary>
         public float[,] V => v;
+
         /// <summary>
-        /// Gets the nonsingular transformation matrix Q.
+        /// Common right invertible factor (n×n); columns are C-orthonormal.
         /// </summary>
         public float[,] Q => q;
+
         /// <summary>
-        /// Gets the generalized cosines (diagonal of C).
+        /// c[i] = ||A q_i||.
         /// </summary>
         public float[] C => c;
+
         /// <summary>
-        /// Gets the generalized sines (diagonal of S).
+        /// s[i] = ||B q_i||.
         /// </summary>
         public float[] S => s;
         #endregion
 
-        #region Private voids
-        private static float[,] Symmetrize(float[,] matrix)
+        #region Constructor
+        /// <summary>
+        /// Computes thin GSVD for A (m×n) and B (p×n).
+        /// </summary>
+        /// <param name="A">Matrix m×n</param>
+        /// <param name="B">Matrix p×n</param>
+        /// <param name="eps">Numerical tolerance</param>
+        public GSVD(float[,] A, float[,] B, float eps = 1e-8f)
         {
-            int n = matrix.GetLength(0);
-            float[,] result = new float[n, n];
+            if (A == null || B == null) throw new ArgumentNullException();
+            m = A.GetLength(0);
+            n = A.GetLength(1);
+            p = B.GetLength(0);
+            if (B.GetLength(1) != n) throw new ArgumentException("A and B must have same number of columns");
+            if (m <= 0 || n <= 0 || p <= 0) throw new ArgumentException("Invalid dimensions");
+
+            var eps0 = 1e-8f;
+            this.eps = eps <= 0 ? eps0 : eps;
+
+            u = new float[m, n];
+            v = new float[p, n];
+            q = new float[n, n];
+            c = new float[n];
+            s = new float[n];
+
+            // Core idea:
+            // C = A^T A + B^T B (SPD for full column-rank [A;B])
+            // Let C = L L^T be Cholesky.
+            // S = L^{-T} (A^T A) L^{-1} is symmetric PSD, EVD(S) = Y Λ Y^T.
+            // q_i = L^{-1} y_i (C-orthonormalized), then u_i = A q_i / ||A q_i||, v_i = B q_i / ||B q_i||.
+
+            // 1) Build normal matrices:
+            var At = Matrice.Transpose(A);
+            var Bt = Matrice.Transpose(B);
+            var AtA = Matrice.Dot(At, A); // n×n
+            var BtB = Matrice.Dot(Bt, B); // n×n
+            var Cmat = Matrice.Add(AtA, BtB); // n×n
+
+            // 2) Robust Cholesky with tiny ridge if needed:
+            float[,] L = null;
+            {
+                bool ok = false;
+                float ridge = 0f;
+                for (int t = 0; t < 5 && !ok; t++)
+                {
+                    try
+                    {
+                        var Csym = Symmetrize(t == 0 ? Cmat : AddRidge(Cmat, ridge));
+                        var chol = new Cholesky(Csym);
+                        L = chol.L; // lower-triangular
+                        ok = true;
+                    }
+                    catch
+                    {
+                        ridge = (ridge == 0f) ? eps0 : ridge * 10f;
+                    }
+                }
+                if (!ok) throw new ArgumentException("C = A^T A + B^T B is not SPD (even with ridge).");
+            }
+
+            // 3) Form S = L^{-T} (A^T A) L^{-1} by solving triangular systems (no explicit inverse):
+            var Ssym = new float[n, n];
+            {
+                var e = new float[n];
+                for (int j = 0; j < n; j++)
+                {
+                    Array.Clear(e, 0, n);
+                    e[j] = 1f;
+
+                    var z = new float[n]; SolveLower(L, z, e);          // z = L^{-1} e_j
+                    var w = Multiply(AtA, z);                           // w = (A^T A) z
+                    var x = new float[n]; SolveUpperT(L, x, w);         // x = L^{-T} w
+
+                    for (int i = 0; i < n; i++) Ssym[i, j] = x[i];
+                }
+                Ssym = Symmetrize(Ssym);
+            }
+
+            // 4) EVD of symmetric S:
+            var evd = new EVD(Ssym, this.eps);
+            var Y = evd.V;               // n×n, columns y_i (orthonormal)
+            var evals = evd.D;           // Complex32[] of length n, ~ real and in [0,1]
+
+            // 5) Sort by λ descending (optional but common):
+            var order = ArgsortRealDesc(evals);
+
+            // 6) Build q, u, v, c, s:
+            for (int idx = 0; idx < n; idx++)
+            {
+                int k = order[idx];
+                float lambda = evals[k].Real;
+                if (lambda < 0f) lambda = 0f;
+                if (lambda > 1f) lambda = 1f;
+
+                // q = L^{-1} y, then C-normalize q so that q^T C q = 1
+                var y = GetCol(Y, k);
+                var qi = new float[n];
+                SolveLower(L, qi, y); // L qi = y
+
+                var Cqi = Multiply(Cmat, qi);
+                float normC = Maths.Sqrt(Math.Max(Dot(qi, Cqi), 0f));
+                if (normC > 0f)
+                {
+                    float inv = 1f / normC;
+                    for (int i = 0; i < n; i++) qi[i] *= inv;
+                }
+                SetCol(q, idx, qi);
+
+                // columns for U,V and their scales
+                var Aq = Multiply(A, qi);
+                var Bq = Multiply(B, qi);
+                float cVal = Norm2(Aq);
+                float sVal = Norm2(Bq);
+
+                // Numerically enforce c^2 + s^2 ≈ 1 (tolerant)
+                float sum2 = cVal * cVal + sVal * sVal;
+                if (sum2 > 0f)
+                {
+                    float scale = 1f / Maths.Sqrt(sum2);
+                    cVal *= scale;
+                    sVal *= scale;
+                    for (int i = 0; i < m; i++) Aq[i] *= scale;
+                    for (int i = 0; i < p; i++) Bq[i] *= scale;
+                }
+
+                c[idx] = cVal;
+                s[idx] = sVal;
+
+                float[] uCol = (cVal > this.eps) ? Scale(Aq, 1f / cVal)
+                                                 : CreateOrthonormalVector(m, u, idx, this.eps);
+                float[] vCol = (sVal > this.eps) ? Scale(Bq, 1f / sVal)
+                                                 : CreateOrthonormalVector(p, v, idx, this.eps);
+
+                // Light modified Gram–Schmidt re-orthogonalization (helps when s ~ 0)
+                if (cVal <= this.eps) MgsReorth(this.u, idx, uCol, eps0);
+                if (sVal <= this.eps) MgsReorth(this.v, idx, vCol, eps0);
+
+                SetCol(u, idx, uCol);
+                SetCol(v, idx, vCol);
+            }
+        }
+        #endregion
+
+        #region Helpers (linear algebra)
+        /// <summary>
+        /// Symmetrizes a square matrix: 0.5*(M + M^T).
+        /// </summary>
+        private static float[,] Symmetrize(float[,] M)
+        {
+            int n = M.GetLength(0), m = M.GetLength(1);
+            if (n != m) throw new ArgumentException("Symmetrize expects square matrix");
+            var S = new float[n, n];
             for (int i = 0; i < n; i++)
             {
                 for (int j = i; j < n; j++)
                 {
-                    float value = 0.5f * (matrix[i, j] + matrix[j, i]);
-                    result[i, j] = value;
-                    result[j, i] = value;
+                    float v = 0.5f * (M[i, j] + M[j, i]);
+                    S[i, j] = v;
+                    S[j, i] = v;
                 }
             }
-            return result;
+            return S;
         }
 
-        private static float[] Multiply(float[,] matrix, float[] vector)
+        /// <summary>
+        /// Adds ridge (tau * I) to a square matrix.
+        /// </summary>
+        private static float[,] AddRidge(float[,] M, float tau)
         {
-            int rows = matrix.GetLength(0);
-            int cols = matrix.GetLength(1);
-            float[] result = new float[rows];
-            for (int i = 0; i < rows; i++)
+            int n = M.GetLength(0), m = M.GetLength(1);
+            if (n != m) throw new ArgumentException("AddRidge expects square matrix");
+            var R = (float[,])M.Clone();
+            for (int i = 0; i < n; i++) R[i, i] += tau;
+            return R;
+        }
+
+        /// <summary>
+        /// Forward substitution: solve L x = b for lower-triangular L (n×n).
+        /// </summary>
+        private static void SolveLower(float[,] L, float[] x, float[] b)
+        {
+            int n = L.GetLength(0);
+            for (int i = 0; i < n; i++)
             {
-                float sum = 0f;
-                for (int j = 0; j < cols; j++)
+                double sum = b[i];
+                for (int k = 0; k < i; k++) sum -= L[i, k] * x[k];
+                x[i] = (float)(sum / L[i, i]);
+            }
+        }
+
+        /// <summary>
+        /// Back substitution for transpose: solve L^T x = b with L lower-triangular.
+        /// </summary>
+        private static void SolveUpperT(float[,] L, float[] x, float[] b)
+        {
+            int n = L.GetLength(0);
+            for (int i = n - 1; i >= 0; i--)
+            {
+                double sum = b[i];
+                for (int k = i + 1; k < n; k++) sum -= L[k, i] * x[k];
+                x[i] = (float)(sum / L[i, i]);
+            }
+        }
+
+        /// <summary>
+        /// Matrix-vector product (M v).
+        /// </summary>
+        private static float[] Multiply(float[,] M, float[] v)
+        {
+            int r = M.GetLength(0), c = M.GetLength(1);
+            if (v.Length != c) throw new ArgumentException();
+            var y = new float[r];
+
+            for (int i = 0; i < r; i++)
+            {
+                double s = 0.0;
+                for (int j = 0; j < c; j++) s += M[i, j] * v[j];
+                y[i] = (float)s;
+            }
+            return y;
+        }
+
+        /// <summary>
+        /// Euclidean 2-norm of vector.
+        /// </summary>
+        private static float Norm2(float[] v)
+        {
+            double s = 0.0;
+            for (int i = 0; i < v.Length; i++) s += (double)v[i] * v[i];
+            return (float)Math.Sqrt(s);
+        }
+
+        /// <summary>
+        /// Dot product of vectors.
+        /// </summary>
+        private static float Dot(float[] a, float[] b)
+        {
+            if (a.Length != b.Length) throw new ArgumentException();
+            double s = 0.0;
+            for (int i = 0; i < a.Length; i++) s += (double)a[i] * b[i];
+            return (float)s;
+        }
+
+        /// <summary>
+        /// Returns a scaled copy of vector.
+        /// </summary>
+        private static float[] Scale(float[] v, float alpha)
+        {
+            var w = new float[v.Length];
+            for (int i = 0; i < v.Length; i++) w[i] = alpha * v[i];
+            return w;
+        }
+
+        /// <summary>
+        /// Gets a column j from matrix M as a vector.
+        /// </summary>
+        private static float[] GetCol(float[,] M, int j)
+        {
+            int r = M.GetLength(0);
+            var v = new float[r];
+            for (int i = 0; i < r; i++) v[i] = M[i, j];
+            return v;
+        }
+
+        /// <summary>
+        /// Sets column j of matrix M to vector v.
+        /// </summary>
+        private static void SetCol(float[,] M, int j, float[] v)
+        {
+            int r = M.GetLength(0);
+            if (v.Length != r) throw new ArgumentException();
+            for (int i = 0; i < r; i++) M[i, j] = v[i];
+        }
+
+        /// <summary>
+        /// Modified Gram–Schmidt re-orthogonalization of vector 'v' against first 'uptoCol' columns of M.
+        /// </summary>
+        private static void MgsReorth(float[,] M, int uptoCol, float[] v, float tol)
+        {
+            for (int j = 0; j < uptoCol; j++)
+            {
+                var w = GetCol(M, j);
+                float alpha = Dot(w, v);
+                for (int i = 0; i < v.Length; i++) v[i] -= alpha * w[i];
+            }
+            float nrm = Norm2(v);
+            if (nrm > tol)
+            {
+                float inv = 1f / nrm;
+                for (int i = 0; i < v.Length; i++) v[i] *= inv;
+            }
+        }
+
+        /// <summary>
+        /// Creates an orthonormal vector completing the current set of columns in M (fallback when scale ~ 0).
+        /// </summary>
+        private static float[] CreateOrthonormalVector(int dim, float[,] M, int uptoCol, float tol)
+        {
+            var rand = new Random(1234 + uptoCol);
+            var v = new float[dim];
+            for (int i = 0; i < dim; i++) v[i] = (float)(rand.NextDouble() - 0.5);
+            MgsReorth(M, uptoCol, v, tol);
+            // If degenerate, pick a canonical basis direction not spanned yet:
+            if (Norm2(v) < tol)
+            {
+                for (int k = 0; k < dim; k++)
                 {
-                    sum += matrix[i, j] * vector[j];
-                }
-                result[i] = sum;
-            }
-            return result;
-        }
-
-        private static float[] Scale(float[] vector, float scale)
-        {
-            float[] result = new float[vector.Length];
-            for (int i = 0; i < vector.Length; i++)
-            {
-                result[i] = vector[i] * scale;
-            }
-            return result;
-        }
-
-        private static void SetColumn(float[,] matrix, int column, float[] data)
-        {
-            int rows = matrix.GetLength(0);
-            for (int i = 0; i < rows; i++)
-            {
-                matrix[i, column] = (i < data.Length) ? data[i] : 0f;
-            }
-        }
-
-        private static float[] CreateOrthonormalVector(int size, float[,] existing, int count, float eps)
-        {
-            float[] candidate = new float[size];
-            for (int attempt = 0; attempt < size; attempt++)
-            {
-                for (int i = 0; i < size; i++)
-                    candidate[i] = 0f;
-                candidate[attempt] = 1f;
-
-                for (int j = 0; j < count; j++)
-                {
-                    float[] prev = existing.GetCol(j);
-                    float proj = prev.Dot(candidate);
-                    for (int i = 0; i < size; i++)
-                        candidate[i] -= proj * prev[i];
-                }
-
-                float norm = candidate.Norm();
-                if (norm > eps)
-                {
-                    for (int i = 0; i < size; i++)
-                        candidate[i] /= norm;
-                    return candidate;
+                    Array.Clear(v, 0, dim);
+                    v[k] = 1f;
+                    MgsReorth(M, uptoCol, v, tol);
+                    if (Norm2(v) >= tol) break;
                 }
             }
-
-            for (int i = 0; i < size; i++)
-                candidate[i] = 0f;
-            candidate[0] = 1f;
-
-            for (int j = 0; j < count; j++)
-            {
-                float[] prev = existing.GetCol(j);
-                float proj = prev.Dot(candidate);
-                for (int i = 0; i < size; i++)
-                    candidate[i] -= proj * prev[i];
-            }
-
-            float fallbackNorm = candidate.Norm();
-            if (fallbackNorm > 0f)
-            {
-                for (int i = 0; i < size; i++)
-                    candidate[i] /= fallbackNorm;
-            }
-
-            return candidate;
+            return v;
         }
 
+        /// <summary>
+        /// Returns indices that sort eigenvalues (Complex32) by descending real part.
+        /// </summary>
+        private static int[] ArgsortRealDesc(Complex32[] vals)
+        {
+            int n = vals.Length;
+            var idx = new int[n];
+            for (int i = 0; i < n; i++) idx[i] = i;
+            Array.Sort(idx, (i, j) => -vals[i].Real.CompareTo(vals[j].Real));
+            return idx;
+        }
         #endregion
     }
 }

--- a/sources/UMapx.xml
+++ b/sources/UMapx.xml
@@ -13118,6 +13118,49 @@
             Gets the orthogonal matrix Q.
             </summary>
         </member>
+        <member name="T:UMapx.Decomposition.GSVD">
+            <summary>
+            Defines generalized singular value decomposition for a pair of real matrices.
+            </summary>
+            <remarks>
+            Finds orthogonal matrices U and V, and a nonsingular matrix Q such that
+            Uᵀ * A * Q = diag(C) and Vᵀ * B * Q = diag(S) with non-negative diagonals
+            satisfying Cᵀ * C + Sᵀ * S = I. Only single precision (float) arithmetic is supported.
+            </remarks>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.#ctor(System.Single[0:,0:],System.Single[0:,0:],System.Single)">
+            <summary>
+            Initializes generalized singular value decomposition.
+            </summary>
+            <param name="A">Matrix A (m × n)</param>
+            <param name="B">Matrix B (p × n)</param>
+            <param name="eps">Tolerance used when detecting rank deficiencies</param>
+        </member>
+        <member name="P:UMapx.Decomposition.GSVD.U">
+            <summary>
+            Gets the left orthogonal factor U (m × n with orthonormal columns).
+            </summary>
+        </member>
+        <member name="P:UMapx.Decomposition.GSVD.V">
+            <summary>
+            Gets the right orthogonal factor V (p × n with orthonormal columns).
+            </summary>
+        </member>
+        <member name="P:UMapx.Decomposition.GSVD.Q">
+            <summary>
+            Gets the nonsingular transformation matrix Q.
+            </summary>
+        </member>
+        <member name="P:UMapx.Decomposition.GSVD.C">
+            <summary>
+            Gets the generalized cosines (diagonal of C).
+            </summary>
+        </member>
+        <member name="P:UMapx.Decomposition.GSVD.S">
+            <summary>
+            Gets the generalized sines (diagonal of S).
+            </summary>
+        </member>
         <member name="T:UMapx.Decomposition.Hessenberg">
             <summary>
             Defines decomposition with a cast to Hessenberg form.

--- a/sources/UMapx.xml
+++ b/sources/UMapx.xml
@@ -13120,45 +13120,107 @@
         </member>
         <member name="T:UMapx.Decomposition.GSVD">
             <summary>
-            Defines generalized singular value decomposition for a pair of real matrices.
+            Generalized SVD (thin GSVD) for a pair of matrices A (m×n), B (p×n).
+            Returns orthonormal U (m×n), V (p×n), invertible Q (n×n),
+            and vectors C[i] = ||A q_i||, S[i] = ||B q_i|| with C[i]^2 + S[i]^2 = 1.
             </summary>
-            <remarks>
-            Finds orthogonal matrices U and V, and a nonsingular matrix Q such that
-            Uᵀ * A * Q = diag(C) and Vᵀ * B * Q = diag(S) with non-negative diagonals
-            satisfying Cᵀ * C + Sᵀ * S = I. Only single precision (float) arithmetic is supported.
-            </remarks>
-        </member>
-        <member name="M:UMapx.Decomposition.GSVD.#ctor(System.Single[0:,0:],System.Single[0:,0:],System.Single)">
-            <summary>
-            Initializes generalized singular value decomposition.
-            </summary>
-            <param name="A">Matrix A (m × n)</param>
-            <param name="B">Matrix B (p × n)</param>
-            <param name="eps">Tolerance used when detecting rank deficiencies</param>
         </member>
         <member name="P:UMapx.Decomposition.GSVD.U">
             <summary>
-            Gets the left orthogonal factor U (m × n with orthonormal columns).
+            Left factor with orthonormal columns (m×n).
             </summary>
         </member>
         <member name="P:UMapx.Decomposition.GSVD.V">
             <summary>
-            Gets the right orthogonal factor V (p × n with orthonormal columns).
+            Right factor with orthonormal columns (p×n).
             </summary>
         </member>
         <member name="P:UMapx.Decomposition.GSVD.Q">
             <summary>
-            Gets the nonsingular transformation matrix Q.
+            Common right invertible factor (n×n); columns are C-orthonormal.
             </summary>
         </member>
         <member name="P:UMapx.Decomposition.GSVD.C">
             <summary>
-            Gets the generalized cosines (diagonal of C).
+            c[i] = ||A q_i||.
             </summary>
         </member>
         <member name="P:UMapx.Decomposition.GSVD.S">
             <summary>
-            Gets the generalized sines (diagonal of S).
+            s[i] = ||B q_i||.
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.#ctor(System.Single[0:,0:],System.Single[0:,0:],System.Single)">
+            <summary>
+            Computes thin GSVD for A (m×n) and B (p×n).
+            </summary>
+            <param name="A">Matrix m×n</param>
+            <param name="B">Matrix p×n</param>
+            <param name="eps">Numerical tolerance</param>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.Symmetrize(System.Single[0:,0:])">
+            <summary>
+            Symmetrizes a square matrix: 0.5*(M + M^T).
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.AddRidge(System.Single[0:,0:],System.Single)">
+            <summary>
+            Adds ridge (tau * I) to a square matrix.
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.SolveLower(System.Single[0:,0:],System.Single[],System.Single[])">
+            <summary>
+            Forward substitution: solve L x = b for lower-triangular L (n×n).
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.SolveUpperT(System.Single[0:,0:],System.Single[],System.Single[])">
+            <summary>
+            Back substitution for transpose: solve L^T x = b with L lower-triangular.
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.Multiply(System.Single[0:,0:],System.Single[])">
+            <summary>
+            Matrix-vector product (M v).
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.Norm2(System.Single[])">
+            <summary>
+            Euclidean 2-norm of vector.
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.Dot(System.Single[],System.Single[])">
+            <summary>
+            Dot product of vectors.
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.Scale(System.Single[],System.Single)">
+            <summary>
+            Returns a scaled copy of vector.
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.GetCol(System.Single[0:,0:],System.Int32)">
+            <summary>
+            Gets a column j from matrix M as a vector.
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.SetCol(System.Single[0:,0:],System.Int32,System.Single[])">
+            <summary>
+            Sets column j of matrix M to vector v.
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.MgsReorth(System.Single[0:,0:],System.Int32,System.Single[],System.Single)">
+            <summary>
+            Modified Gram–Schmidt re-orthogonalization of vector 'v' against first 'uptoCol' columns of M.
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.CreateOrthonormalVector(System.Int32,System.Single[0:,0:],System.Int32,System.Single)">
+            <summary>
+            Creates an orthonormal vector completing the current set of columns in M (fallback when scale ~ 0).
+            </summary>
+        </member>
+        <member name="M:UMapx.Decomposition.GSVD.ArgsortRealDesc(UMapx.Core.Complex32[])">
+            <summary>
+            Returns indices that sort eigenvalues (Complex32) by descending real part.
             </summary>
         </member>
         <member name="T:UMapx.Decomposition.Hessenberg">


### PR DESCRIPTION
## Summary
- implement a generalized singular value decomposition class for single-precision matrices in `UMapx.Decomposition`
- solve the GSVD via Cholesky and symmetric eigenvalue reductions and expose U, V, Q, C and S factors
- add normalization and orthonormal fallback helpers for handling rank-deficient columns

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1616a9c8832194a7c31ddd6e0bec