### PR TITLE
Fix hyperbolic secant excess kurtosis

### DIFF
--- a/sources/Distribution/HyperbolicSecant.cs
+++ b/sources/Distribution/HyperbolicSecant.cs
@@ -64,7 +64,8 @@ namespace UMapx.Distribution
         /// </remarks>
         public float Excess
         {
-            get { return -1f; }
+            // E[X^4] = 5 for the standard hyperbolic secant, so kurtosis 5 ⇒ excess 2.
+            get { return 2f; }
         }
         /// <summary>
         /// Gets the support interval of the argument.


### PR DESCRIPTION
## Summary
- correct the hyperbolic secant distribution's excess kurtosis constant
- document the link to the distribution's fourth moment to avoid regression

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd500941f0832198bce1cf859204c5