### PR TITLE
Adjust Laplace transform damping and add tests

### DIFF
--- a/sources/Transform/FastLaplaceTransform.cs
+++ b/sources/Transform/FastLaplaceTransform.cs
@@ -81,12 +81,12 @@ namespace UMapx.Transform
         /// <returns>Array</returns>
         public override Complex32[] Forward(Complex32[] A)
         {
-            // Fourier transform:
-            Complex32[] B = FFT.Forward(A);
+            // Apply Laplace damping before Fourier transform:
+            Complex32[] weighted = (Complex32[])A.Clone();
+            LaplaceTransform.ApplyLaplaceOperator(weighted, sigma);
 
-            // Fourier to Laplace transform:
-            LaplaceTransform.ApplyLaplaceOperator(B, sigma);
-            return B;
+            // Fourier transform of damped signal:
+            return FFT.Forward(weighted);
         }
         /// <summary>
         /// Backward transform.
@@ -95,12 +95,12 @@ namespace UMapx.Transform
         /// <returns>Array</returns>
         public override Complex32[] Backward(Complex32[] B)
         {
-            // Laplace to Fourier transform:
-            Complex32[] A = (Complex32[])B.Clone();
-            LaplaceTransform.ApplyLaplaceInverseOperator(A, sigma);
-
             // Fourier transform:
-            return FFT.Backward(A);
+            Complex32[] A = FFT.Backward(B);
+
+            // Compensate Laplace damping:
+            LaplaceTransform.ApplyLaplaceInverseOperator(A, sigma);
+            return A;
         }
         #endregion
     }

--- a/sources/Transform/LaplaceTransform.cs
+++ b/sources/Transform/LaplaceTransform.cs
@@ -81,12 +81,12 @@ namespace UMapx.Transform
         /// <returns>Array</returns>
         public override Complex32[] Forward(Complex32[] A)
         {
-            // Fourier transform:
-            Complex32[] B = DFT.Forward(A);
+            // Apply Laplace damping before Fourier transform:
+            Complex32[] weighted = (Complex32[])A.Clone();
+            LaplaceTransform.ApplyLaplaceOperator(weighted, sigma);
 
-            // Fourier to Laplace transform:
-            LaplaceTransform.ApplyLaplaceOperator(B, sigma);
-            return B;
+            // Fourier transform of damped signal:
+            return DFT.Forward(weighted);
         }
         /// <summary>
         /// Backward transform.
@@ -95,12 +95,12 @@ namespace UMapx.Transform
         /// <returns>Array</returns>
         public override Complex32[] Backward(Complex32[] B)
         {
-            // Laplace to Fourier transform:
-            Complex32[] A = (Complex32[])B.Clone();
-            LaplaceTransform.ApplyLaplaceInverseOperator(A, sigma);
-
             // Fourier transform:
-            return DFT.Backward(A);
+            Complex32[] A = DFT.Backward(B);
+
+            // Compensate Laplace damping:
+            LaplaceTransform.ApplyLaplaceInverseOperator(A, sigma);
+            return A;
         }
         #endregion
 

--- a/sources/UMapx.sln
+++ b/sources/UMapx.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30413.136
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UMapx", "UMapx.csproj", "{33A1E4B7-F6A3-4EA8-8446-4E37016D375B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UMapx.Tests", "..\tests\UMapx.Tests\UMapx.Tests.csproj", "{CC450A19-7359-486D-B97C-F26CD613582E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{33A1E4B7-F6A3-4EA8-8446-4E37016D375B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{33A1E4B7-F6A3-4EA8-8446-4E37016D375B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{33A1E4B7-F6A3-4EA8-8446-4E37016D375B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC450A19-7359-486D-B97C-F26CD613582E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC450A19-7359-486D-B97C-F26CD613582E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC450A19-7359-486D-B97C-F26CD613582E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC450A19-7359-486D-B97C-F26CD613582E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/UMapx.Tests/LaplaceTransformTests.cs
+++ b/tests/UMapx.Tests/LaplaceTransformTests.cs
@@ -1,0 +1,108 @@
+using System;
+using UMapx.Core;
+using UMapx.Transform;
+using Xunit;
+
+namespace UMapx.Tests
+{
+    public class LaplaceTransformTests
+    {
+
+        [Theory]
+        [InlineData(0.0)]
+        [InlineData(0.35)]
+        public void LaplaceTransformMatchesExpected(double sigma)
+        {
+            float sigmaF = (float)sigma;
+            Complex32[] signal = CreateUnitStep(8);
+            Complex32[] original = (Complex32[])signal.Clone();
+            Complex32[] expected = ComputeExpected(original, sigmaF, normalized: true);
+            var transform = new LaplaceTransform(sigmaF, normalized: true);
+
+            Complex32[] actual = transform.Forward(signal);
+
+            AssertComplexArrayEqual(expected, actual, 1e-4f);
+
+            Complex32[] reconstructed = transform.Backward(actual);
+            AssertComplexArrayEqual(original, reconstructed, 1e-4f);
+        }
+
+        [Theory]
+        [InlineData(0.0)]
+        [InlineData(0.35)]
+        public void FastLaplaceTransformMatchesExpected(double sigma)
+        {
+            float sigmaF = (float)sigma;
+            Complex32[] signal = CreateUnitStep(8);
+            Complex32[] original = (Complex32[])signal.Clone();
+            Complex32[] expected = ComputeExpected(original, sigmaF, normalized: true);
+            var transform = new FastLaplaceTransform(sigmaF, normalized: true);
+
+            Complex32[] actual = transform.Forward(signal);
+
+            AssertComplexArrayEqual(expected, actual, 1e-4f);
+
+            if (sigmaF == 0f)
+            {
+                var fft = new FastFourierTransform(normalized: true);
+                Complex32[] fftResult = fft.Forward(original);
+                AssertComplexArrayEqual(fftResult, actual, 1e-4f);
+            }
+
+            Complex32[] reconstructed = transform.Backward(actual);
+            AssertComplexArrayEqual(original, reconstructed, 1e-4f);
+        }
+
+        private static Complex32[] CreateUnitStep(int length)
+        {
+            var result = new Complex32[length];
+            for (int i = 0; i < length; i++)
+            {
+                result[i] = new Complex32(1f, 0f);
+            }
+            return result;
+        }
+
+        private static Complex32[] ComputeExpected(Complex32[] signal, float sigma, bool normalized)
+        {
+            int length = signal.Length;
+            var result = new Complex32[length];
+            double scale = normalized ? Math.Sqrt(length) : 1.0;
+
+            for (int k = 0; k < length; k++)
+            {
+                double sumRe = 0.0;
+                double sumIm = 0.0;
+
+                for (int n = 0; n < length; n++)
+                {
+                    double weight = Math.Exp(-sigma * n);
+                    double re = signal[n].Real * weight;
+                    double im = signal[n].Imag * weight;
+                    double angle = -2.0 * Math.PI * k * n / length;
+                    double cos = Math.Cos(angle);
+                    double sin = Math.Sin(angle);
+
+                    sumRe += re * cos - im * sin;
+                    sumIm += re * sin + im * cos;
+                }
+
+                result[k] = new Complex32((float)(sumRe / scale), (float)(sumIm / scale));
+            }
+
+            return result;
+        }
+
+        private static void AssertComplexArrayEqual(Complex32[] expected, Complex32[] actual, float tolerance)
+        {
+            Assert.Equal(expected.Length, actual.Length);
+            for (int i = 0; i < expected.Length; i++)
+            {
+                Assert.True(Math.Abs(expected[i].Real - actual[i].Real) <= tolerance,
+                    $"Real parts differ at index {i}: expected {expected[i].Real}, actual {actual[i].Real}");
+                Assert.True(Math.Abs(expected[i].Imag - actual[i].Imag) <= tolerance,
+                    $"Imaginary parts differ at index {i}: expected {expected[i].Imag}, actual {actual[i].Imag}");
+            }
+        }
+    }
+}

--- a/tests/UMapx.Tests/UMapx.Tests.csproj
+++ b/tests/UMapx.Tests/UMapx.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\sources\UMapx.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- apply the exponential damping factor before running the discrete and fast Laplace transforms and undo it after the inverse FFT
- add an xUnit test project that validates the Laplace transforms on a unit-step for sigma = 0 and sigma > 0, including a regression check against the FFT

## Testing
- ~/.dotnet/dotnet test sources/UMapx.sln

------
https://chatgpt.com/codex/tasks/task_e_68ced0ee40f083218ead8da5dbfb7bd4