### PR TITLE
Clarify Toc method documentation

### DIFF
--- a/sources/Core/Debugger.cs
+++ b/sources/Core/Debugger.cs
@@ -388,9 +388,8 @@ namespace UMapx.Core
             tic = Environment.TickCount;
         }
         /// <summary>
-        /// Prints elapsed time in milliseconds.
+        /// Prints elapsed time in milliseconds to the console.
         /// </summary>
-        /// <returns>Int</returns>
         public static void Toc()
         {
             Console.WriteLine($"Elapsed time is {Environment.TickCount - tic} milliseconds");


### PR DESCRIPTION
## Summary
- clarify the Toc summary to note it writes elapsed time to the console
- remove the incorrect `<returns>` XML documentation tag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d69d5fd3e88321b7b24eb428c3e5b0