### PR TITLE
Clarify GlobalMeans XML documentation

### DIFF
--- a/sources/Imaging/FlatFieldCorrection.cs
+++ b/sources/Imaging/FlatFieldCorrection.cs
@@ -149,10 +149,9 @@ namespace UMapx.Imaging
             });
         }
         /// <summary>
-        /// Global means.
+        /// Computes global channel means and stores them in <see cref="mR"/>, <see cref="mG"/> and <see cref="mB"/>.
         /// </summary>
         /// <param name="bmData">Bitmap data</param>
-        /// <returns>Array</returns>
         private unsafe void GlobalMeans(BitmapData bmData)
         {
             byte* p = (byte*)bmData.Scan0.ToPointer();


### PR DESCRIPTION
## Summary
- clarify the GlobalMeans summary comment to note which fields are populated
- remove the incorrect `<returns>` entry from the XML documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d69d6556248321ba1159494d6c8d19