### PR TITLE
Reset stream position before constructing converted bitmaps

### DIFF
--- a/sources/Imaging/BitmapFormat.cs
+++ b/sources/Imaging/BitmapFormat.cs
@@ -52,6 +52,7 @@ namespace UMapx.Imaging
         {
             MemoryStream stream = new MemoryStream();
             b.Save(stream, ImageFormat.Jpeg);
+            stream.Position = 0;
 
             return new Bitmap(stream);
         }
@@ -64,6 +65,7 @@ namespace UMapx.Imaging
         {
             MemoryStream stream = new MemoryStream();
             b.Save(stream, ImageFormat.Bmp);
+            stream.Position = 0;
 
             return new Bitmap(stream);
         }
@@ -76,6 +78,7 @@ namespace UMapx.Imaging
         {
             MemoryStream stream = new MemoryStream();
             b.Save(stream, ImageFormat.Gif);
+            stream.Position = 0;
 
             return new Bitmap(stream);
         }
@@ -88,6 +91,7 @@ namespace UMapx.Imaging
         {
             MemoryStream stream = new MemoryStream();
             b.Save(stream, ImageFormat.Png);
+            stream.Position = 0;
 
             return new Bitmap(stream);
         }
@@ -100,6 +104,7 @@ namespace UMapx.Imaging
         {
             MemoryStream stream = new MemoryStream();
             b.Save(stream, ImageFormat.Tiff);
+            stream.Position = 0;
 
             return new Bitmap(stream);
         }


### PR DESCRIPTION
## Summary
- reset the memory stream position to the beginning after saving bitmaps in each conversion helper
- ensure the returned Bitmap instances are created from the start of the stream

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d820574fcc8321bcac732e7f691241