### PR TITLE
Fix max/min search bounds

### DIFF
--- a/sources/Imaging/Statistics.cs
+++ b/sources/Imaging/Statistics.cs
@@ -312,7 +312,7 @@ namespace UMapx.Imaging
         public static int Max(int[] data, out int index)
         {
             index = 0;
-            int length = data.Length - 1, i;
+            int length = data.Length, i;
             int maximum = data[index];
 
             for (i = 1; i < length; i++)
@@ -344,7 +344,7 @@ namespace UMapx.Imaging
         public static int Min(int[] data, out int index)
         {
             index = 0;
-            int length = data.Length - 1, i;
+            int length = data.Length, i;
             int minimum = data[index];
 
             for (i = 1; i < length; i++)


### PR DESCRIPTION
## Summary
- ensure Statistics.Max/Min iterate across the full array length by adjusting loop bounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d81f625ac48321a4676182abff9bc6