### PR TITLE
Clarify XML comments for max/min statistics helpers

### DIFF
--- a/sources/Imaging/Statistics.cs
+++ b/sources/Imaging/Statistics.cs
@@ -295,20 +295,20 @@ namespace UMapx.Imaging
 
         #region AForge
         /// <summary>
-        /// Gets the index of the maximum element of the array.
+        /// Gets the maximum value of the array.
         /// </summary>
         /// <param name="data">Array</param>
-        /// <returns>Integer number</returns>
+        /// <returns>Maximum value</returns>
         public static int Max(int[] data)
         {
             return Max(data, out _);
         }
         /// <summary>
-        /// Gets the index of the maximum element of the array.
+        /// Gets the maximum value of the array and outputs the index of that value.
         /// </summary>
         /// <param name="data">Array</param>
-        /// <param name="index">Max index</param>
-        /// <returns>Integer number</returns>
+        /// <param name="index">Outputs the index of the maximum element</param>
+        /// <returns>Maximum value</returns>
         public static int Max(int[] data, out int index)
         {
             index = 0;
@@ -327,20 +327,20 @@ namespace UMapx.Imaging
             return maximum;
         }
         /// <summary>
-        /// Gets the index of the minimum element of the array.
+        /// Gets the minimum value of the array.
         /// </summary>
         /// <param name="data">Array</param>
-        /// <returns>Integer number</returns>
+        /// <returns>Minimum value</returns>
         public static int Min(int[] data)
         {
             return Min(data, out _);
         }
         /// <summary>
-        /// Gets the index of the minimum element of the array.
+        /// Gets the minimum value of the array and outputs the index of that value.
         /// </summary>
         /// <param name="data">Array</param>
-        /// <param name="index">Min index</param>
-        /// <returns>Tuple of integer numbers</returns>
+        /// <param name="index">Outputs the index of the minimum element</param>
+        /// <returns>Minimum value</returns>
         public static int Min(int[] data, out int index)
         {
             index = 0;


### PR DESCRIPTION
## Summary
- clarify that Max/Min overloads return the extreme value and expose the index via the out parameter
- align return descriptions for the single-parameter Max/Min helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d81f515b0c8321b5590aa6565a9e57