### PR TITLE
Use Maths.Atan2 for gradient angle calculation

### DIFF
--- a/sources/Imaging/Convolution.cs
+++ b/sources/Imaging/Convolution.cs
@@ -309,14 +309,14 @@ namespace UMapx.Imaging
             return Maths.Sqrt(Gx * Gx + Gy * Gy);
         }
         /// <summary>
-        /// Gets the angle of the gradient operator.
+        /// Gets the angle of the gradient operator using Atan2 for proper quadrant determination.
         /// </summary>
         /// <param name="Gx">Gradient X</param>
         /// <param name="Gy">Gradient Y</param>
         /// <returns>Value</returns>
         public static float Tetta(float Gx, float Gy)
         {
-            return Maths.Atan(Gx / Gy);
+            return Maths.Atan2(Gy, Gx);
         }
         #endregion
 


### PR DESCRIPTION
## Summary
- switch the Sobel gradient angle helper to use `Maths.Atan2` with the correct argument order
- clarify the accompanying XML comment to mention the Atan2-based calculation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d81f4996988321ac021f2ef3a2997c