### PR TITLE
Fix alpha channel swap in horizontal flip

### DIFF
--- a/sources/Imaging/Flip.cs
+++ b/sources/Imaging/Flip.cs
@@ -91,6 +91,10 @@ namespace UMapx.Imaging
 
                     while (l < w2)
                     {
+                        b = p[3];
+                        p[3] = pSrc[3];
+                        pSrc[3] = b;
+
                         b = p[2];
                         p[2] = pSrc[2];
                         pSrc[2] = b;


### PR DESCRIPTION
## Summary
- ensure the horizontal flip operation also swaps the alpha channel to prevent artifacts

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d82358870c83218e0aee1bde90eb9c