### PR TITLE
Handle empty rectangles in Rectangles.Min

### DIFF
--- a/sources/Imaging/Rectangles.cs
+++ b/sources/Imaging/Rectangles.cs
@@ -199,7 +199,7 @@ namespace UMapx.Imaging
             var length = rectangles.Length;
             var rectangle = Rectangle.Empty;
             var area = int.MaxValue;
-            var min = int.MaxValue;
+            var min = -1;
 
             // do job
             for (int i = 0; i < length; i++)
@@ -219,7 +219,7 @@ namespace UMapx.Imaging
             }
 
             // output
-            return length > 0 ? rectangles[min] : rectangle;
+            return min >= 0 ? rectangles[min] : Rectangle.Empty;
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary
- initialize the minimum index sentinel to detect when no non-empty rectangles are found
- return `Rectangle.Empty` when the `Min` method receives only empty rectangles

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d82637652083218ce73188d27e8efa