### PR TITLE
Fix noise offset bounds in PointMatrix

### DIFF
--- a/sources/Imaging/PointMatrix.cs
+++ b/sources/Imaging/PointMatrix.cs
@@ -132,14 +132,14 @@ namespace UMapx.Imaging
                 {
                     newX = rnd.Next(value) - nHalf;
 
-                    if (x + newX > 0 && x + newX < width)
+                    if (x + newX >= 0 && x + newX < width)
                         noise[x, y].X = newX;
                     else
                         noise[x, y].X = 0;
 
                     newY = rnd.Next(value) - nHalf;
 
-                    if (y + newY > 0 && y + newY < width)
+                    if (y + newY >= 0 && y + newY < height)
                         noise[x, y].Y = newY;
                     else
                         noise[x, y].Y = 0;


### PR DESCRIPTION
## Summary
- ensure the noise offsets in PointMatrix respect image width and height bounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d82aa5f1f08321aa6233e7544d1e0e