### PR TITLE
Fix depth conversion pixel format guard

### DIFF
--- a/sources/Imaging/DepthMatrix.cs
+++ b/sources/Imaging/DepthMatrix.cs
@@ -35,8 +35,8 @@ namespace UMapx.Imaging
         /// <returns>Depth</returns>
         public unsafe static ushort[,] ToDepth(this BitmapData bmData)
         {
-            if (bmData.PixelFormat == PixelFormat.Format24bppRgb || bmData.PixelFormat == PixelFormat.Format32bppArgb)
-                throw new NotSupportedException("Only support Format24bppRgb and Format32bppArgb pixelFormat");
+            if (bmData.PixelFormat != PixelFormat.Format24bppRgb && bmData.PixelFormat != PixelFormat.Format32bppArgb)
+                throw new NotSupportedException("Depth conversion supports only Format24bppRgb and Format32bppArgb pixel formats.");
 
             var p = Image.GetPixelFormatSize(bmData.PixelFormat) / 8;
             var width = bmData.Width;


### PR DESCRIPTION
## Summary
- correct the pixel format guard in `DepthMatrix.ToDepth(BitmapData)` to allow 24bpp RGB and 32bpp ARGB inputs
- clarify the exception text to indicate that other pixel formats are unsupported

## Testing
- `dotnet build sources/UMapx.csproj` *(fails: `dotnet` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d83341ef388321bb5a571cfc29abcf