### PR TITLE
Fix normalization for local histogram equalization edges

### DIFF
--- a/sources/Imaging/LocalHistogramEqualization.cs
+++ b/sources/Imaging/LocalHistogramEqualization.cs
@@ -94,9 +94,8 @@ namespace UMapx.Imaging
             {
                 int[] H = new int[256];
                 int[] cdf = new int[256];
-                int n = l0 * l1;
                 int brightness;
-                float dn = 255.0f / n;
+                float dn;
 
                 int x, i, j, ir, jr, yr, xr, irstride;
                 int ystride, v;
@@ -107,6 +106,7 @@ namespace UMapx.Imaging
 
                 for (x = 0; x < width; x++)
                 {
+                    int hits = 0;
                     xr = x - rh;
                     v = ystride + x * 4;
 
@@ -126,11 +126,13 @@ namespace UMapx.Imaging
                             p = &src[irstride + jr * 4];
                             brightness = (p[2] + p[1] + p[0]) / 3;
                             H[brightness]++;
+                            hits++;
                         }
                     }
                     #endregion
 
                     #region Density function
+                    dn = hits > 0 ? 255.0f / hits : 0.0f;
                     cdf[0] = H[0];
 
                     for (i = 1; i < 256; i++)


### PR DESCRIPTION
## Summary
- track the number of valid samples accumulated in each local histogram window
- normalize cumulative distribution using the actual hit count to avoid border darkening

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d833390b6c832188ee23eef965ecf7