### PR TITLE
Fix channel-specific means in flat-field correction

### DIFF
--- a/sources/Imaging/FlatFieldCorrection.cs
+++ b/sources/Imaging/FlatFieldCorrection.cs
@@ -139,11 +139,11 @@ namespace UMapx.Imaging
                     }
                     if (pSrc[k + 1] != 0)
                     {
-                        p[k + 1] = Maths.Byte(p[k + 1] * mR / pSrc[k + 1]);
+                        p[k + 1] = Maths.Byte(p[k + 1] * mG / pSrc[k + 1]);
                     }
                     if (pSrc[k] != 0)
                     {
-                        p[k] = Maths.Byte(p[k] * mR / pSrc[k]);
+                        p[k] = Maths.Byte(p[k] * mB / pSrc[k]);
                     }
                 }
             });


### PR DESCRIPTION
## Summary
- update the flat-field correction to scale the green and blue channels with their own means

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d839357c7083218250b0af0fab0ec9